### PR TITLE
Fix session directory path for lobby discovery builds

### DIFF
--- a/Assets/Scripts/Networking/Runtime/Admin/ServerControlPanel.cs
+++ b/Assets/Scripts/Networking/Runtime/Admin/ServerControlPanel.cs
@@ -83,7 +83,7 @@ namespace Game.Net
         }
 
         private static string BuildShutdownPath(string id) =>
-            Path.Combine(Application.persistentDataPath, "mps_control", id + ".shutdown");
+            Path.Combine(SessionDirectory.ControlDirectory, id + ".shutdown");
 
         private void SetStatus(string s) { if (statusText) statusText.text = s; }
     }

--- a/Assets/Scripts/Networking/Runtime/Server/ServerControlListener.cs
+++ b/Assets/Scripts/Networking/Runtime/Server/ServerControlListener.cs
@@ -1,4 +1,4 @@
-// Graceful shutdown for headless servers via file signal: <persistentDataPath>/mps_control/<SessionId>.shutdown
+// Graceful shutdown for headless servers via file signal: <SessionDirectory.ControlDirectory>/<SessionId>.shutdown
 // Add this component to Lobby, Match_1v1, Match_2v2 server scenes.
 
 using System.Collections;
@@ -22,7 +22,7 @@ namespace Game.Net
             while (!nm.IsServer) yield return null;
             while (string.IsNullOrEmpty(SessionContext.SessionId)) yield return null;
 
-            var dir = Path.Combine(Application.persistentDataPath, "mps_control");
+            var dir = SessionDirectory.ControlDirectory;
             Directory.CreateDirectory(dir);
             _signalPath = Path.Combine(dir, SessionContext.SessionId + ".shutdown");
 


### PR DESCRIPTION
## Summary
- resolve the session directory to a shared location (with env-var overrides) so Windows builds read the same file
- expose the resolved base directory for control signals and update server shutdown listeners/panel to use it

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d998762f208328b31ed4e7d9c8e382