### PR TITLE
Fix lobby player input being frozen on spawn

### DIFF
--- a/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
@@ -98,6 +98,7 @@ namespace Game.Net
         Camera _cam; IsometricCamera _isoCam; int _camBindTries;
 
         bool _inputPaused;
+        float _localSpawnTime = float.PositiveInfinity;
         bool _frozen;
 
         private readonly NetworkVariable<TeamId> _team = new(TeamId.A);
@@ -145,6 +146,7 @@ namespace Game.Net
             {
                 SetupInputAndCamera();
                 TrySnapToGroundImmediate(); // client visual safety
+                _localSpawnTime = Time.time;
             }
             SetInputPaused(false);
 
@@ -177,11 +179,15 @@ namespace Game.Net
             if (_aDash != null) _aDash.performed -= OnDashPerformed;
             _map = null; _aMove = _aMouse = _aSprint = _aDash = null;
 
+            _localSpawnTime = float.PositiveInfinity;
+
             _netPosition.OnValueChanged -= OnPositionChanged;
             _netYaw.OnValueChanged -= OnYawChanged;
             _netVelocity.OnValueChanged -= OnVelocityChanged;
             _netIsDashing.OnValueChanged -= OnDashingChanged;
         }
+
+        public float LocalSpawnTime => _localSpawnTime;
 
         // ==== HUD binding API (for PlayerHUDBinder) ====
         public void AssignHud(Image sprintFillUI, TMP_Text sprintLabelUI, Image dashFillUI, TMP_Text dashLabelUI)


### PR DESCRIPTION
## Summary
- track each player's local spawn time so gameplay scripts can detect immediate post-spawn state
- gate the lobby play trigger to only react to the local player and wait a short grace period before opening the panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2cc1d9e083289b8feebb88de2fd8