### PR TITLE
Fix spawn selection visuals and LOS fading stability

### DIFF
--- a/Assets/Scripts/Camera/LineOfSightTransparency.cs
+++ b/Assets/Scripts/Camera/LineOfSightTransparency.cs
@@ -19,6 +19,8 @@ public sealed class LineOfSightTransparency : MonoBehaviour
     [Min(0f)] public float fadeSpeed = 12f;
     [Tooltip("How often to refresh cached renderers for a tag (seconds).")]
     [Min(0.1f)] public float recacheInterval = 2f;
+    [Tooltip("Keep occluders transparent for this many seconds after the ray no longer hits them.")]
+    [Min(0f)] public float occlusionHoldSeconds = 0.2f;
     public bool debugRay;
 
     readonly Dictionary<string, TagGroup> _groups = new Dictionary<string, TagGroup>(8);
@@ -41,7 +43,7 @@ public sealed class LineOfSightTransparency : MonoBehaviour
         var dir = toTarget / distance;
         _activeTags.Clear();
 
-        var hits = Physics.RaycastAll(origin, dir, distance, occluderLayers, QueryTriggerInteraction.Ignore);
+        var hits = Physics.RaycastAll(origin, dir, distance, occluderLayers, QueryTriggerInteraction.Collide);
         for (int i = 0; i < hits.Length; i++)
         {
             var hit = hits[i];
@@ -69,6 +71,15 @@ public sealed class LineOfSightTransparency : MonoBehaviour
             if (!_groups.TryGetValue(tag, out var group)) continue;
 
             bool shouldFade = _activeTags.Contains(tag);
+            if (shouldFade)
+            {
+                group.holdUntil = Time.unscaledTime + occlusionHoldSeconds;
+            }
+            else if (occlusionHoldSeconds > 0f && Time.unscaledTime < group.holdUntil)
+            {
+                shouldFade = true;
+            }
+
             float targetAlphaMultiplier = shouldFade ? Mathf.Clamp01(occludedAlpha) : 1f;
             UpdateGroup(group, targetAlphaMultiplier);
 
@@ -100,6 +111,7 @@ public sealed class LineOfSightTransparency : MonoBehaviour
     {
         group.entries.Clear();
         group.lastPopulateTime = Time.unscaledTime;
+        group.holdUntil = 0f;
 
         Renderer[] tempRenderers = null;
         try
@@ -197,6 +209,7 @@ public sealed class LineOfSightTransparency : MonoBehaviour
     {
         public readonly List<Entry> entries = new List<Entry>();
         public float lastPopulateTime;
+        public float holdUntil;
 
         public void RemoveDestroyed()
         {

--- a/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
+++ b/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
@@ -61,9 +61,9 @@ namespace Game.Net
         [Header("Timings")]
         [SerializeField, Min(1f)] private int countdownSeconds = 3;
         [SerializeField, Min(3f)] private float cinematicSeconds = 3.5f;
-        [SerializeField, Min(3f)] private float spawnSelectSeconds = 10f;
+        [SerializeField, Min(3f)] private float spawnSelectSeconds = 15f;
         [SerializeField, Min(10f)] private float roundDurationSeconds = 90f;
-        [SerializeField, Min(2f)] private float roundEndDelaySeconds = 3f;
+        [SerializeField, Min(0f)] private float roundEndDelaySeconds = 0f;
 
         [Header("Win Conditions")]
         [SerializeField, Min(1)] private int winsNeeded = 5;
@@ -120,8 +120,9 @@ namespace Game.Net
 
         // Client state
         private bool _selecting;
-    private Bounds _myAreaBounds;
-    private bool _myAreaBlocked;
+        private Bounds _myAreaBounds;
+        private bool _myAreaBlocked;
+        private TeamId _myTeam;
         private float _spawnDeadlineLocal;
         private Coroutine _flyCo, _selectCo, _uiCo;
         private GameObject _spawnCursor;
@@ -305,7 +306,7 @@ namespace Game.Net
 
                 var bounds = areas.GetTeamBounds(team);
                 bool blocked = areas.IsAreaBlocked(team);
-                BeginSpawnSelectClientRpc(bounds.center, bounds.size, spawnSelectSeconds, blocked, ToClient(cid));
+                BeginSpawnSelectClientRpc(bounds.center, bounds.size, spawnSelectSeconds, blocked, team, ToClient(cid));
             }
 
             StartCoroutine(CoWatchSpawnDeadline());
@@ -434,20 +435,20 @@ namespace Game.Net
         }
 
         [ClientRpc]
-        void BeginSpawnSelectClientRpc(Vector3 areaCenter, Vector3 areaSize, float seconds, bool blocked, ClientRpcParams p = default)
+        void BeginSpawnSelectClientRpc(Vector3 areaCenter, Vector3 areaSize, float seconds, bool blocked, TeamId team, ClientRpcParams p = default)
         {
             if (!IsClient) return;
 
             _myAreaBounds = new Bounds(areaCenter, areaSize);
             _spawnDeadlineLocal = Time.unscaledTime + seconds;
             _myAreaBlocked = blocked;
+            _myTeam = team;
             _selecting = true;
 
             // Highlight with carved holes from overlapping "No Spawn" triggers.
             List<Bounds> holes = null;
             if (areas) holes = areas.GetBlockerIntersectionsFor(_myAreaBounds, null);
-            // Paint green with per-hole red overlays (even if area is globally unblocked).
-            SpawnAreaHighlighter.SetMode(SpawnAreaHighlighter.Mode.Choosing, _myAreaBounds, /*targetBlocked*/ false, holes);
+            ApplySpawnHighlightLayout(holes);
 // [Match1v1] Client sees green area with red "holes" subtracted.
 
             // Run the intro pan once, then open the spawn UI.
@@ -462,11 +463,6 @@ namespace Game.Net
 
             // No pan path: frame camera from bounds and open UI now.
             FrameSpawnCameraFullMap();
-            ShowCanvas(spawnCanvas, true);
-            if (spawnHintText)
-            {
-                spawnHintText.text = _myAreaBlocked ? "Spawn blocked in this area" : "Click to choose spawn";
-            }
 
             if (!_spawnCursor)
             {
@@ -495,6 +491,10 @@ namespace Game.Net
             if (_spawnCursor)
                 _spawnCursor.SetActive(false);
 
+            ShowCanvas(spawnCanvas, true);
+            if (spawnHintText)
+                spawnHintText.text = Mathf.CeilToInt(seconds).ToString("0");
+
             // Fade configured objects during selection
             ApplySelectTransparency(true);
 
@@ -521,6 +521,32 @@ namespace Game.Net
             _selectCo = StartCoroutine(CoSpawnSelectTimer());
         }
 
+        void ApplySpawnHighlightLayout(List<Bounds> holes)
+        {
+            Bounds enemy = default;
+            Bounds neutral = default;
+            Bounds map = default;
+
+            if (areas)
+            {
+                enemy = areas.GetTeamBounds(OpposingTeam(_myTeam));
+                neutral = areas.GetNeutralBounds();
+                map = areas.GetMapBounds();
+            }
+
+            if (map.size.sqrMagnitude <= 0f)
+                map = _myAreaBounds;
+
+            SpawnAreaHighlighter.SetLayout(
+                SpawnAreaHighlighter.Mode.Choosing,
+                _myAreaBounds,
+                enemy,
+                neutral,
+                map,
+                _myAreaBlocked,
+                holes);
+        }
+
         IEnumerator CoSpawnSelectTimer()
         {
             while (_selecting && Time.unscaledTime < _spawnDeadlineLocal)
@@ -528,7 +554,7 @@ namespace Game.Net
                 if (spawnHintText)
                 {
                     float remain = Mathf.Max(0f, _spawnDeadlineLocal - Time.unscaledTime);
-                    spawnHintText.text = _myAreaBlocked ? $"Spawn blocked in this area ({remain:0}s)" : $"Click to choose spawn ({remain:0}s)";
+                    spawnHintText.text = Mathf.CeilToInt(remain).ToString("0");
                 }
                 yield return null;
             }
@@ -893,7 +919,7 @@ namespace Game.Net
             _selecting = false;
             _myAreaBlocked = false;
             ShowCanvas(spawnCanvas, false);
-            SpawnAreaHighlighter.SetMode(SpawnAreaHighlighter.Mode.Hidden, new Bounds(), false);
+            SpawnAreaHighlighter.SetLayout(SpawnAreaHighlighter.Mode.Hidden, default, default, default, default, false, null);
 
             // Restore transparency
             ApplySelectTransparency(false);
@@ -1024,6 +1050,8 @@ namespace Game.Net
         {
             return p.x >= b.min.x && p.x <= b.max.x && p.z >= b.min.z && p.z <= b.max.z;
         }
+
+        static TeamId OpposingTeam(TeamId team) => team == TeamId.A ? TeamId.B : TeamId.A;
 
         static Transform FindDeep(Transform root, string name)
         {
@@ -1194,23 +1222,30 @@ namespace Game.Net
 // clear ship/stand-ins NOW that spawn-select begins, then frame and show UI
 ClearCinematicShip();
 FrameSpawnCameraFullMap();
-// Re-send carved holes (guard against blockers changing during pan)
-{
-    List<Bounds> holes = null;
-    if (areas) holes = areas.GetBlockerIntersectionsFor(_myAreaBounds, null);
-    SpawnAreaHighlighter.SetMode(SpawnAreaHighlighter.Mode.Choosing, _myAreaBounds, /*targetBlocked*/ false, holes);
-}
-// Ensure cursor exists and starts hidden
-EnsureSpawnCursor();
-// Fade configured objects during selection
-ApplySelectTransparency(true);
-_panCo = null;
-ShowCanvas(spawnCanvas, true);
-if (spawnHintText)
-    spawnHintText.text = _myAreaBlocked ? "Spawn blocked in this area" : "Click to choose spawn";
-// Start the timer now that UI is open
-if (_selectCo != null) StopCoroutine(_selectCo);
-_selectCo = StartCoroutine(CoSpawnSelectTimer());
+            // Re-send carved holes (guard against blockers changing during pan)
+            {
+                List<Bounds> holes = null;
+                if (areas) holes = areas.GetBlockerIntersectionsFor(_myAreaBounds, null);
+                ApplySpawnHighlightLayout(holes);
+            }
+
+            // Ensure cursor exists and starts hidden
+            EnsureSpawnCursor();
+
+            // Fade configured objects during selection
+            ApplySelectTransparency(true);
+            _panCo = null;
+
+            ShowCanvas(spawnCanvas, true);
+            if (spawnHintText)
+            {
+                float remain = Mathf.Max(0f, _spawnDeadlineLocal - Time.unscaledTime);
+                spawnHintText.text = Mathf.CeilToInt(remain).ToString("0");
+            }
+
+            // Start the timer now that UI is open
+            if (_selectCo != null) StopCoroutine(_selectCo);
+            _selectCo = StartCoroutine(CoSpawnSelectTimer());
         }
 
         // Ensure a SeatMount exists under the ship and return it.

--- a/Assets/Scripts/Networking/Runtime/Match/SpawnAreaHighlighter.cs
+++ b/Assets/Scripts/Networking/Runtime/Match/SpawnAreaHighlighter.cs
@@ -8,6 +8,14 @@ public sealed class SpawnAreaHighlighter : MonoBehaviour
 {
     public enum Mode { Hidden, Choosing }
 
+    public enum AreaRole
+    {
+        Friendly,
+        Enemy,
+        Neutral,
+        MapBounds
+    }
+
     [Header("Behavior")]
     [Tooltip("When true, ignore this object's BoxCollider during Choosing and render exactly the target Bounds sent from the controller.")]
     [SerializeField] bool followTargetBounds = true;
@@ -18,10 +26,17 @@ public sealed class SpawnAreaHighlighter : MonoBehaviour
     [SerializeField] Color blockedColor = new Color(0.8f, 0.2f, 0.2f, 0.35f);
     [SerializeField, Min(0f)] float yOffset = 0.02f;
 
+    [Header("Role")]
+    [SerializeField] AreaRole areaRole = AreaRole.Friendly;
+    [SerializeField] bool autoDetectRole = true;
+
     static readonly List<SpawnAreaHighlighter> s_All = new();
     static Mode s_Mode = Mode.Hidden;
-    static Bounds s_Target;
-    static bool s_TargetBlocked;
+    static Bounds s_FriendlyBounds;
+    static Bounds s_EnemyBounds;
+    static Bounds s_NeutralBounds;
+    static Bounds s_MapBounds;
+    static bool s_FriendlyBlocked;
     // Carved "holes" from blockers (world-space XZ AABBs)
     static readonly List<Bounds> s_Holes = new();
 // [Highlighter] Store per-area carved rectangles.
@@ -29,12 +44,14 @@ public sealed class SpawnAreaHighlighter : MonoBehaviour
     BoxCollider _col;
     MeshRenderer _mr;
     MeshFilter _mf;
+    bool _roleResolved;
 
     void OnEnable()
     {
         _col = GetComponent<BoxCollider>();
         Build();
         if (!s_All.Contains(this)) s_All.Add(this);
+        _roleResolved = false;
         Apply();
     }
 
@@ -85,18 +102,27 @@ public sealed class SpawnAreaHighlighter : MonoBehaviour
         }
     }
 
-    public static void SetMode(Mode mode, Bounds target, bool targetBlocked = false, List<Bounds> holes = null)
+    public static void SetLayout(Mode mode, Bounds friendly, Bounds enemy, Bounds neutral, Bounds map,
+        bool friendlyBlocked = false, List<Bounds> holes = null)
     {
         s_Mode = mode;
-        s_Target = target;
-        s_TargetBlocked = targetBlocked;
+        s_FriendlyBounds = friendly;
+        s_EnemyBounds = enemy;
+        s_NeutralBounds = neutral;
+        s_MapBounds = map;
+        s_FriendlyBlocked = friendlyBlocked;
 
         s_Holes.Clear();
         if (holes != null) s_Holes.AddRange(holes);
 
-        for (int i = 0; i < s_All.Count; i++) s_All[i].Apply();
+        for (int i = 0; i < s_All.Count; i++)
+        {
+            var h = s_All[i];
+            if (!h) continue;
+            h._roleResolved = false;
+            h.Apply();
+        }
     }
-// [Highlighter] New holes argument from controller.
 
     void Apply()
     {
@@ -105,8 +131,27 @@ public sealed class SpawnAreaHighlighter : MonoBehaviour
         if (s_Mode == Mode.Hidden) { _mr.enabled = false; ClearHoleVisuals(); return; }
         _mr.enabled = true;
 
-        // Either render our own collider (legacy) or exactly the controller's target bounds.
-        Bounds renderWorld = followTargetBounds ? s_Target : ToWorldBounds(_col);
+        if (!_roleResolved && autoDetectRole)
+        {
+            areaRole = GuessRoleFromCollider(areaRole);
+            _roleResolved = true;
+        }
+
+        if (!TryGetBoundsForRole(out var target))
+        {
+            _mr.enabled = false;
+            ClearHoleVisuals();
+            return;
+        }
+
+        // Either render our own collider (legacy) or the layout's bounds for our role.
+        Bounds renderWorld = followTargetBounds ? target : ToWorldBounds(_col);
+        if (renderWorld.size.x <= 0.001f || renderWorld.size.z <= 0.001f)
+        {
+            _mr.enabled = false;
+            ClearHoleVisuals();
+            return;
+        }
 
         // Place/scale visual quad directly from the render bounds.
         _mr.transform.position = new Vector3(renderWorld.center.x, _col.bounds.center.y + yOffset, renderWorld.center.z);
@@ -114,10 +159,13 @@ public sealed class SpawnAreaHighlighter : MonoBehaviour
         _mr.transform.localScale = new Vector3(renderWorld.size.x, 1f, renderWorld.size.z);
 
         var mat = _mr.sharedMaterial; if (!mat) return;
-        mat.color = followTargetBounds ? (s_TargetBlocked ? blockedColor : activeColor) : inactiveColor;
+        mat.color = ResolveColorForRole(followTargetBounds);
 
-        // Carve holes relative to what we're rendering.
-        if (followTargetBounds) BuildHoleMasks(renderWorld); else ClearHoleVisuals();
+        // Carve holes relative to what we're rendering when highlighting the friendly area.
+        if (followTargetBounds && areaRole == AreaRole.Friendly)
+            BuildHoleMasks(renderWorld);
+        else
+            ClearHoleVisuals();
     }
 
 // Build child quads that write **stencil only** (no color), so the area material can cull them.
@@ -176,7 +224,9 @@ void BuildHoleMasks(Bounds myWorld)
         var t = holesRoot.GetChild(i);
         if (t) Destroy(t.gameObject);
     }
-}    void ClearHoleVisuals()
+}
+
+    void ClearHoleVisuals()
     {
         if (_mr == null) return;
         var holesRoot = _mr.transform.Find("Holes");
@@ -215,6 +265,78 @@ void BuildHoleMasks(Bounds myWorld)
     }
 // [Highlighter] Adds hole quads and intersection helper.
 
+    bool TryGetBoundsForRole(out Bounds bounds)
+    {
+        bounds = default;
+        switch (areaRole)
+        {
+            case AreaRole.Friendly: bounds = s_FriendlyBounds; break;
+            case AreaRole.Enemy:    bounds = s_EnemyBounds;   break;
+            case AreaRole.Neutral:  bounds = s_NeutralBounds; break;
+            case AreaRole.MapBounds:bounds = s_MapBounds;     break;
+            default: bounds = s_FriendlyBounds; break;
+        }
+
+        if (!followTargetBounds)
+            return true;
+
+        return bounds.size.x > 0.001f && bounds.size.z > 0.001f;
+    }
+
+    Color ResolveColorForRole(bool usingLayoutBounds)
+    {
+        if (!usingLayoutBounds)
+            return inactiveColor;
+
+        return areaRole switch
+        {
+            AreaRole.Friendly => s_FriendlyBlocked ? blockedColor : activeColor,
+            AreaRole.Enemy    => inactiveColor,
+            AreaRole.Neutral  => inactiveColor,
+            AreaRole.MapBounds=> inactiveColor,
+            _ => inactiveColor
+        };
+    }
+
+    AreaRole GuessRoleFromCollider(AreaRole fallback)
+    {
+        if (!_col) return fallback;
+
+        var world = ToWorldBounds(_col);
+        if (world.size.sqrMagnitude <= 0.0001f)
+            return fallback;
+
+        AreaRole bestRole = fallback;
+        float bestScore = float.PositiveInfinity;
+
+        void Consider(AreaRole role, Bounds target)
+        {
+            if (target.size.sqrMagnitude <= 0.0001f) return;
+            float score = ScoreBounds(world, target);
+            if (score < bestScore)
+            {
+                bestScore = score;
+                bestRole = role;
+            }
+        }
+
+        Consider(AreaRole.Friendly, s_FriendlyBounds);
+        Consider(AreaRole.Enemy, s_EnemyBounds);
+        Consider(AreaRole.Neutral, s_NeutralBounds);
+        Consider(AreaRole.MapBounds, s_MapBounds);
+
+        return bestRole;
+    }
+
+    static float ScoreBounds(Bounds source, Bounds target)
+    {
+        var sizeDiff = Mathf.Abs(source.size.x - target.size.x) + Mathf.Abs(source.size.z - target.size.z);
+        var src = new Vector2(source.center.x, source.center.z);
+        var dst = new Vector2(target.center.x, target.center.z);
+        float centerDiff = Vector2.Distance(src, dst);
+        return sizeDiff + centerDiff;
+    }
+
     static Bounds ToWorldBounds(BoxCollider c)
     {
         // Use Unity's world AABB (handles rotation and scale).
@@ -226,10 +348,4 @@ void BuildHoleMasks(Bounds myWorld)
         return p.x >= b.min.x && p.x <= b.max.x && p.z >= b.min.z && p.z <= b.max.z;
     }
 
-    static bool SizesRoughlyMatchXZ(Vector3 a, Vector3 b)
-    {
-        // Tolerate authoring/scale differences
-        float eps = Mathf.Max(0.5f, 0.1f * Mathf.Max(a.x, a.z));
-        return Mathf.Abs(a.x - b.x) <= eps && Mathf.Abs(a.z - b.z) <= eps;
-    }
 }


### PR DESCRIPTION
## Summary
- highlight each team’s spawn zone with carved blockers, show only the countdown timer, extend selection to 15 s, and remove the post-round delay
- upgrade the spawn area highlighter to support role-aware layouts with automatic enemy/neutral detection
- keep line-of-sight fades stable by holding transparency briefly and honoring trigger colliders

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_69040b59e63c832883e46212659f0e3b