### PR TITLE
Ensure player reveal custom pass and layer setup

### DIFF
--- a/Assets/Prefabs/Player/PlayerAvatar Animation.prefab
+++ b/Assets/Prefabs/Player/PlayerAvatar Animation.prefab
@@ -9,7 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2175930713061618387}
-  m_Layer: 0
+  - component: {fileID: 4230793381085330056}
+  - component: {fileID: 7211393495198156950}
+  m_Layer: 7
   m_Name: PlayerVisualAnchor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22,7 +24,7 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2189414339830708796}
+  m_GameObject: {fileID: 7629307799589511846}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -40,8 +42,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5914470287193299296}
-  - component: {fileID: 4230793381085330056}
-  - component: {fileID: 7211393495198156950}
   - component: {fileID: 4610652831622128449}
   m_Layer: 0
   m_Name: PlayerAvatar Animation
@@ -73,7 +73,7 @@ MeshFilter:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7629307799589511846}
+  m_GameObject: {fileID: 2189414339830708796}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &7211393495198156950
 MeshRenderer:
@@ -81,7 +81,7 @@ MeshRenderer:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7629307799589511846}
+  m_GameObject: {fileID: 2189414339830708796}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -144,7 +144,7 @@ GameObject:
   - component: {fileID: 8293086637473939724}
   - component: {fileID: 4247808313785581503}
   - component: {fileID: 1568220164743985275}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Player/PlayerAvatar.prefab
+++ b/Assets/Prefabs/Player/PlayerAvatar.prefab
@@ -9,7 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2175930713061618387}
-  m_Layer: 0
+  - component: {fileID: 4230793381085330056}
+  - component: {fileID: 7211393495198156950}
+  m_Layer: 7
   m_Name: PlayerVisualAnchor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22,7 +24,7 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2189414339830708796}
+  m_GameObject: {fileID: 7629307799589511846}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -40,7 +42,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5985286790363318194}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Hand Mount
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -102,8 +104,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5914470287193299296}
-  - component: {fileID: 4230793381085330056}
-  - component: {fileID: 7211393495198156950}
   - component: {fileID: 3171105039355217481}
   - component: {fileID: 3191172038672659176}
   - component: {fileID: 8807297918959326603}
@@ -149,7 +149,7 @@ MeshFilter:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7629307799589511846}
+  m_GameObject: {fileID: 2189414339830708796}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &7211393495198156950
 MeshRenderer:
@@ -157,7 +157,7 @@ MeshRenderer:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7629307799589511846}
+  m_GameObject: {fileID: 2189414339830708796}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -366,7 +366,7 @@ MonoBehaviour:
   sprintLabel: {fileID: 0}
   dashFill: {fileID: 0}
   dashLabel: {fileID: 0}
-  modelRoot: {fileID: 0}
+  modelRoot: {fileID: 2175930713061618387}
   useLegacyStateReplication: 0
 --- !u!114 &3944781503140636565
 MonoBehaviour:
@@ -518,7 +518,7 @@ GameObject:
   - component: {fileID: 4247808313785581503}
   - component: {fileID: 1568220164743985275}
   - component: {fileID: 8827757300112603286}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Camera/LineOfSightOccluder.cs
+++ b/Assets/Scripts/Camera/LineOfSightOccluder.cs
@@ -98,6 +98,7 @@ sealed class DepthState
     public Material[] mats;
     public int[] origSortingPriority;
     public int origSortingOrder;
+    public int[] origRenderQueue;
     public float[] origZWrite, origTZWrite, origPrepass;
     public bool initialized;
     public bool appliedFaded;
@@ -456,6 +457,7 @@ static void r_GetBlock(ref Faded f)
         {
             st.mats = r.materials; // instanced
             st.origSortingPriority = new int[st.mats.Length];
+            st.origRenderQueue = new int[st.mats.Length];
             st.origZWrite = new float[st.mats.Length];
             st.origTZWrite = new float[st.mats.Length];
             st.origPrepass = new float[st.mats.Length];
@@ -464,6 +466,7 @@ static void r_GetBlock(ref Faded f)
                 var m = st.mats[i];
                 if (!m) continue;
                 st.origSortingPriority[i] = m.HasProperty(SortingPriorityId) ? m.GetInt(SortingPriorityId) : 0;
+                st.origRenderQueue[i]     = m.renderQueue;
                 st.origZWrite[i]          = m.HasProperty(ZWriteId) ? m.GetFloat(ZWriteId) : 0f;
                 st.origTZWrite[i]         = m.HasProperty(TransparentZWriteId) ? m.GetFloat(TransparentZWriteId) : 0f;
                 st.origPrepass[i]         = m.HasProperty(EnableTransparentDepthPrepassId) ? m.GetFloat(EnableTransparentDepthPrepassId) : 0f;
@@ -484,6 +487,9 @@ static void r_GetBlock(ref Faded f)
                 if (m.HasProperty(TransparentZWriteId)) m.SetFloat(TransparentZWriteId, 0f);
                 if (m.HasProperty(EnableTransparentDepthPrepassId)) m.SetFloat(EnableTransparentDepthPrepassId, 0f);
                 if (m.HasProperty(SortingPriorityId)) m.SetInt(SortingPriorityId, -50);
+
+                // Pull occluder before player reveal queue (player ~3000+ priority)
+                if (m.renderQueue > 2950) m.renderQueue = 2950;
             }
             r.sortingOrder = -50;
             st.appliedFaded = true;
@@ -498,6 +504,7 @@ static void r_GetBlock(ref Faded f)
                 if (m.HasProperty(TransparentZWriteId)) m.SetFloat(TransparentZWriteId, st.origTZWrite[i]);
                 if (m.HasProperty(EnableTransparentDepthPrepassId)) m.SetFloat(EnableTransparentDepthPrepassId, st.origPrepass[i]);
                 if (m.HasProperty(SortingPriorityId)) m.SetInt(SortingPriorityId, st.origSortingPriority[i]);
+                m.renderQueue = st.origRenderQueue[i];
             }
             r.sortingOrder = st.origSortingOrder;
             st.appliedFaded = false;

--- a/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
@@ -88,6 +88,8 @@ namespace Game.Net
         Rigidbody _rb;
         CapsuleCollider _capsule;
 
+        static bool s_warnedMissingPlayerRevealLayer;
+
         Renderer[] _renderers;
         Collider[] _colliders;
 
@@ -190,6 +192,12 @@ namespace Game.Net
 
                 FogOfWarOverlayPlane.InstallFor(Camera.main);
 
+                if (TryGetPlayerRevealLayer(out var revealLayer))
+                {
+                    ApplyPlayerRevealLayer(revealLayer);
+                    PlayerOccludedRevealInstaller.EnsureInstalled(1 << revealLayer);
+                }
+
                 // Force local model fully visible each spawn (guards against any fade components).
                 EnsureLocalModelVisible();
 
@@ -246,6 +254,8 @@ namespace Game.Net
 
             var root = modelRoot ? modelRoot : transform;
             _renderers = root.GetComponentsInChildren<Renderer>(true);
+            if (TryGetPlayerRevealLayer(out var revealLayer))
+                ApplyPlayerRevealLayer(revealLayer);
             _colliders = GetComponentsInChildren<Collider>(true);
 
             _stamina = sprintStaminaMax;
@@ -448,6 +458,9 @@ void OnActiveSlotChanged()
 
                 var los = _cam.GetComponent<LineOfSightTransparency>() ?? _cam.gameObject.AddComponent<LineOfSightTransparency>();
                 los.target = transform;
+
+                if (TryGetPlayerRevealLayer(out var revealLayer))
+                    EnsureCameraLayer(_cam, revealLayer);
             }
         }
 
@@ -866,6 +879,53 @@ void OnActiveSlotChanged()
                 }
                 r.SetPropertyBlock(mpb);
             }
+        }
+
+        bool TryGetPlayerRevealLayer(out int revealLayer)
+        {
+            revealLayer = LayerMask.NameToLayer("PlayerReveal");
+            if (revealLayer >= 0) return true;
+
+            if (!s_warnedMissingPlayerRevealLayer)
+            {
+                s_warnedMissingPlayerRevealLayer = true;
+                Debug.LogWarning("[LOS] Missing PlayerReveal layer; occlusion reveal pass disabled.");
+            }
+            return false;
+        }
+
+        void ApplyPlayerRevealLayer(int revealLayer)
+        {
+            if (revealLayer < 0) return;
+
+            if (modelRoot && !modelRoot.TryGetComponent<Collider>(out _))
+                modelRoot.gameObject.layer = revealLayer;
+
+            var span = GetModelRenderersSpan();
+            if (span.Length == 0)
+            {
+                var root = modelRoot ? modelRoot : transform;
+                _renderers = root.GetComponentsInChildren<Renderer>(true);
+                span = GetModelRenderersSpan();
+                if (span.Length == 0) return;
+            }
+
+            for (int i = 0; i < span.Length; i++)
+            {
+                var r = span[i];
+                if (!r) continue;
+                var go = r.gameObject;
+                if (!go || go.TryGetComponent<Collider>(out _)) continue;
+                go.layer = revealLayer;
+            }
+        }
+
+        static void EnsureCameraLayer(Camera cam, int layer)
+        {
+            if (!cam || layer < 0) return;
+            int bit = 1 << layer;
+            if ((cam.cullingMask & bit) == 0)
+                cam.cullingMask |= bit;
         }
 
         void SetCollidersEnabled(bool enabled)

--- a/Assets/Scripts/Rendering/PlayerOccludedRevealInstaller.cs
+++ b/Assets/Scripts/Rendering/PlayerOccludedRevealInstaller.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.Rendering.HighDefinition;
+
+/// <summary>
+/// Ensures the PlayerOccludedRevealPass exists at runtime so the local player remains visible through occluders.
+/// </summary>
+[DisallowMultipleComponent]
+public sealed class PlayerOccludedRevealInstaller : MonoBehaviour
+{
+    [SerializeField] LayerMask revealLayer = 0;
+
+    static CustomPassVolume s_volume;
+
+    void Awake()
+    {
+        EnsureInstalled(revealLayer);
+    }
+
+    public static void EnsureInstalled(LayerMask revealMask)
+    {
+        if (revealMask == 0) revealMask = 1 << LayerMask.NameToLayer("PlayerReveal");
+
+        if (!s_volume)
+        {
+            s_volume = FindExistingVolume();
+            if (!s_volume)
+            {
+                var go = new GameObject("PlayerOccludedRevealVolume");
+                go.hideFlags = HideFlags.DontSave;
+                Object.DontDestroyOnLoad(go);
+                s_volume = go.AddComponent<CustomPassVolume>();
+            }
+        }
+
+        s_volume.isGlobal = true;
+        s_volume.injectionPoint = CustomPassInjectionPoint.AfterPostProcess;
+
+        var passes = s_volume.customPasses;
+        PlayerOccludedRevealPass revealPass = null;
+        for (int i = 0; i < passes.Count; i++)
+        {
+            revealPass = passes[i] as PlayerOccludedRevealPass;
+            if (revealPass != null)
+                break;
+        }
+
+        if (revealPass == null)
+        {
+            revealPass = ScriptableObject.CreateInstance<PlayerOccludedRevealPass>();
+            revealPass.name = nameof(PlayerOccludedRevealPass);
+            passes.Add(revealPass);
+        }
+
+        revealPass.revealLayer = revealMask;
+    }
+
+    static CustomPassVolume FindExistingVolume()
+    {
+#if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
+        var volumes = Object.FindObjectsByType<CustomPassVolume>(FindObjectsSortMode.InstanceID);
+#else
+        var volumes = Object.FindObjectsOfType<CustomPassVolume>();
+#endif
+        for (int i = 0; i < volumes.Length; i++)
+        {
+            var vol = volumes[i];
+            if (!vol) continue;
+            var passes = vol.customPasses;
+            for (int p = 0; p < passes.Count; p++)
+            {
+                if (passes[p] is PlayerOccludedRevealPass)
+                    return vol;
+            }
+        }
+        return null;
+    }
+}

--- a/Assets/Scripts/Rendering/PlayerOccludedRevealPass.cs
+++ b/Assets/Scripts/Rendering/PlayerOccludedRevealPass.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
+
+/// <summary>
+/// HDRP custom pass that re-renders player meshes so they remain visible through transparent occluders.
+/// </summary>
+[System.Serializable]
+public sealed class PlayerOccludedRevealPass : CustomPass
+{
+    [Tooltip("Layer mask containing player renderers that should be re-drawn through occluders.")]
+    public LayerMask revealLayer = 0;
+
+    protected override void Setup(ScriptableRenderContext renderContext, CommandBuffer cmd) { }
+
+    protected override void Execute(CustomPassContext ctx)
+    {
+        if (revealLayer == 0) return;
+
+        var desc = new RendererListDesc(HDShaderPassNames.s_ForwardAndForwardOnlyPassNames, ctx.cullingResults, ctx.hdCamera.camera)
+        {
+            sortingCriteria = SortingCriteria.CommonTransparent,
+            renderQueueRange = RenderQueueRange.all,
+            layerMask = revealLayer,
+            stateBlock = new RenderStateBlock(RenderStateMask.Depth)
+            {
+                depthState = new DepthState(writeEnabled: false, compareFunction: CompareFunction.GreaterEqual)
+            }
+        };
+
+        CustomPassUtils.DrawRenderers(ctx, desc);
+    }
+
+    protected override void Cleanup() { }
+}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -28,7 +28,7 @@ TagManager:
   - Water
   - UI
   - Projectile
-  - 
+  - PlayerReveal
   - 
   - 
   - Occluder


### PR DESCRIPTION
## Summary
- add a dedicated PlayerReveal layer and move player render meshes to child anchors on that layer
- add a PlayerOccludedRevealPass custom pass plus installer so PlayerReveal renderers are redrawn after post processing
- update LOS transparency/occluder handling to clamp render queues and wire PlayerNetwork to apply reveal layers and camera masking

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_69067417dcc48328aaad89777b4b26b1