### PR TITLE
Ensure LOS occluders render before players and add reveal custom pass

### DIFF
--- a/Assets/Scripts/Camera/LineOfSightOccluder.cs
+++ b/Assets/Scripts/Camera/LineOfSightOccluder.cs
@@ -97,6 +97,7 @@ sealed class DepthState
 {
     public Material[] mats;
     public int[] origSortingPriority;
+    public int[] origRenderQueue;
     public int origSortingOrder;
     public float[] origZWrite, origTZWrite, origPrepass;
     public bool initialized;
@@ -456,6 +457,7 @@ static void r_GetBlock(ref Faded f)
         {
             st.mats = r.materials; // instanced
             st.origSortingPriority = new int[st.mats.Length];
+            st.origRenderQueue = new int[st.mats.Length];
             st.origZWrite = new float[st.mats.Length];
             st.origTZWrite = new float[st.mats.Length];
             st.origPrepass = new float[st.mats.Length];
@@ -464,6 +466,7 @@ static void r_GetBlock(ref Faded f)
                 var m = st.mats[i];
                 if (!m) continue;
                 st.origSortingPriority[i] = m.HasProperty(SortingPriorityId) ? m.GetInt(SortingPriorityId) : 0;
+                st.origRenderQueue[i]     = m.renderQueue;
                 st.origZWrite[i]          = m.HasProperty(ZWriteId) ? m.GetFloat(ZWriteId) : 0f;
                 st.origTZWrite[i]         = m.HasProperty(TransparentZWriteId) ? m.GetFloat(TransparentZWriteId) : 0f;
                 st.origPrepass[i]         = m.HasProperty(EnableTransparentDepthPrepassId) ? m.GetFloat(EnableTransparentDepthPrepassId) : 0f;
@@ -484,6 +487,7 @@ static void r_GetBlock(ref Faded f)
                 if (m.HasProperty(TransparentZWriteId)) m.SetFloat(TransparentZWriteId, 0f);
                 if (m.HasProperty(EnableTransparentDepthPrepassId)) m.SetFloat(EnableTransparentDepthPrepassId, 0f);
                 if (m.HasProperty(SortingPriorityId)) m.SetInt(SortingPriorityId, -50);
+                if (m.renderQueue > 2950) m.renderQueue = 2950;
             }
             r.sortingOrder = -50;
             st.appliedFaded = true;
@@ -498,6 +502,7 @@ static void r_GetBlock(ref Faded f)
                 if (m.HasProperty(TransparentZWriteId)) m.SetFloat(TransparentZWriteId, st.origTZWrite[i]);
                 if (m.HasProperty(EnableTransparentDepthPrepassId)) m.SetFloat(EnableTransparentDepthPrepassId, st.origPrepass[i]);
                 if (m.HasProperty(SortingPriorityId)) m.SetInt(SortingPriorityId, st.origSortingPriority[i]);
+                m.renderQueue = st.origRenderQueue[i];
             }
             r.sortingOrder = st.origSortingOrder;
             st.appliedFaded = false;

--- a/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
@@ -189,6 +189,7 @@ namespace Game.Net
                 fov.follow = modelRoot ? modelRoot : transform;
 
                 FogOfWarOverlayPlane.InstallFor(Camera.main);
+                PlayerOccludedRevealInstaller.InstallFor(Camera.main);
 
                 // Force local model fully visible each spawn (guards against any fade components).
                 EnsureLocalModelVisible();

--- a/Assets/Scripts/Rendering/EnsurePlayerVisibleThroughOccluders.cs
+++ b/Assets/Scripts/Rendering/EnsurePlayerVisibleThroughOccluders.cs
@@ -13,8 +13,13 @@ public sealed class EnsurePlayerVisibleThroughOccluders : MonoBehaviour
     [SerializeField] int sortingPriority = 100;
     [SerializeField] int sortingOrder = 100;
 
+    const string PlayerRevealLayerName = "PlayerReveal";
+    int _playerRevealLayer = -1;
+    bool _warnedColliderLayerConflict;
+
     static readonly int SP = Shader.PropertyToID("_SortingPriority");
     static readonly int TZWrite = Shader.PropertyToID("_TransparentZWrite");
+    static readonly int ZWrite = Shader.PropertyToID("_ZWrite");
     static readonly int TPre = Shader.PropertyToID("_EnableTransparentDepthPrepass");
     static readonly int BaseColor = Shader.PropertyToID("_BaseColor");
     static readonly int ColorId = Shader.PropertyToID("_Color");
@@ -30,15 +35,19 @@ public sealed class EnsurePlayerVisibleThroughOccluders : MonoBehaviour
         if (renderers == null || renderers.Length == 0)
             renderers = GetComponentsInChildren<Renderer>(true);
         Filter();
+        EnsurePlayerRevealLayer();
     }
 
     void LateUpdate()
     {
+        EnsurePlayerRevealLayer();
         var mpb = new MaterialPropertyBlock();
         for (int i = 0; i < renderers.Length; i++)
         {
             var r = renderers[i];
             if (!r) continue;
+
+            ApplyPlayerRevealLayer(r);
 
             // Push material knobs if available.
             var mats = r.sharedMaterials;
@@ -48,6 +57,7 @@ public sealed class EnsurePlayerVisibleThroughOccluders : MonoBehaviour
                 if (!mat) continue;
                 if (mat.HasProperty(SP)) mat.SetInt(SP, sortingPriority);
                 if (mat.HasProperty(TZWrite)) mat.SetFloat(TZWrite, 1f);
+                if (mat.HasProperty(ZWrite)) mat.SetFloat(ZWrite, 1f);
                 if (mat.HasProperty(TPre)) mat.SetFloat(TPre, 1f);
             }
             r.sortingOrder = sortingOrder;
@@ -89,5 +99,28 @@ public sealed class EnsurePlayerVisibleThroughOccluders : MonoBehaviour
             if (!isLos) list.Add(r);
         }
         renderers = list.ToArray();
+    }
+
+    void EnsurePlayerRevealLayer()
+    {
+        if (_playerRevealLayer >= 0) return;
+        _playerRevealLayer = LayerMask.NameToLayer(PlayerRevealLayerName);
+        if (_playerRevealLayer < 0)
+            Debug.LogWarning("[LOS] PlayerReveal layer missing. Players may not render in reveal pass.");
+    }
+
+    void ApplyPlayerRevealLayer(Renderer r)
+    {
+        if (_playerRevealLayer < 0 || !r) return;
+        if (r.gameObject.layer == _playerRevealLayer) return;
+
+        if (!_warnedColliderLayerConflict && r.TryGetComponent<Collider>(out _))
+        {
+            _warnedColliderLayerConflict = true;
+            Debug.LogWarning($"[LOS] Renderer '{r.name}' has a Collider on the same GameObject. Skipping PlayerReveal layer reassignment to avoid collider layer changes.");
+            return;
+        }
+
+        r.gameObject.layer = _playerRevealLayer;
     }
 }

--- a/Assets/Scripts/Rendering/PlayerOccludedRevealInstaller.cs
+++ b/Assets/Scripts/Rendering/PlayerOccludedRevealInstaller.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
+
+/// <summary>
+/// Ensures the HDRP custom pass that re-renders players exists at runtime.
+/// </summary>
+public static class PlayerOccludedRevealInstaller
+{
+    const string VolumeName = "PlayerOccludedRevealVolume";
+
+    public static CustomPassVolume InstallFor(Camera cam)
+    {
+        if (!cam) return null;
+
+        var existingVolumes = cam.GetComponentsInChildren<CustomPassVolume>(includeInactive: true);
+        foreach (var volume in existingVolumes)
+        {
+            if (TryConfigure(volume))
+                return volume;
+        }
+
+        var go = new GameObject(VolumeName);
+        go.transform.SetParent(cam.transform, worldPositionStays: false);
+        var created = go.AddComponent<CustomPassVolume>();
+        created.isGlobal = true;
+        created.injectionPoint = CustomPassInjectionPoint.AfterPostProcess;
+        created.targetCamera = cam;
+        created.priority = 100f;
+        created.hideFlags = HideFlags.DontSave;
+
+        var pass = ScriptableObject.CreateInstance<PlayerOccludedRevealPass>();
+        pass.name = nameof(PlayerOccludedRevealPass);
+        pass.playerLayer = GetPlayerLayerMask();
+
+        created.customPasses = new List<CustomPass> { pass };
+        return created;
+    }
+
+    static bool TryConfigure(CustomPassVolume volume)
+    {
+        if (!volume) return false;
+        volume.isGlobal = true;
+        volume.injectionPoint = CustomPassInjectionPoint.AfterPostProcess;
+        volume.priority = Mathf.Max(volume.priority, 100f);
+        if (!volume.targetCamera)
+            volume.targetCamera = volume.GetComponentInParent<Camera>();
+
+        var mask = GetPlayerLayerMask();
+        var found = false;
+        foreach (var pass in volume.customPasses)
+        {
+            if (pass is PlayerOccludedRevealPass reveal)
+            {
+                reveal.playerLayer = mask;
+                found = true;
+            }
+        }
+
+        if (!found)
+        {
+            var reveal = ScriptableObject.CreateInstance<PlayerOccludedRevealPass>();
+            reveal.name = nameof(PlayerOccludedRevealPass);
+            reveal.playerLayer = mask;
+            if (volume.customPasses == null)
+                volume.customPasses = new List<CustomPass>();
+            volume.customPasses.Add(reveal);
+        }
+
+        return true;
+    }
+
+    static LayerMask GetPlayerLayerMask()
+    {
+        int layer = LayerMask.NameToLayer("PlayerReveal");
+        if (layer < 0)
+        {
+            Debug.LogWarning("[LOS] PlayerReveal layer is missing. Custom pass will not render any objects.");
+            return 0;
+        }
+        return 1 << layer;
+    }
+}

--- a/Assets/Scripts/Rendering/PlayerOccludedRevealPass.cs
+++ b/Assets/Scripts/Rendering/PlayerOccludedRevealPass.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
+
+/// <summary>
+/// Custom pass that re-renders player meshes behind transparent occluders so they stay visible.
+/// </summary>
+public sealed class PlayerOccludedRevealPass : CustomPass
+{
+    [Tooltip("Only renderers on these layers are re-drawn.")]
+    public LayerMask playerLayer = 0;
+
+    static readonly ShaderTagId[] ShaderTags =
+    {
+        new ShaderTagId("Forward"),
+        new ShaderTagId("ForwardOnly"),
+        new ShaderTagId("SRPDefaultUnlit"),
+    };
+
+    FilteringSettings _filtering;
+    RenderStateBlock _stateBlock;
+
+    protected override void Setup(ScriptableRenderContext renderContext, CommandBuffer cmd)
+    {
+        _stateBlock = new RenderStateBlock(RenderStateMask.Depth)
+        {
+            depthState = new DepthState(writeEnabled: false, compareFunction: CompareFunction.GreaterEqual)
+        };
+        UpdateFiltering();
+    }
+
+    protected override void Execute(CustomPassContext ctx)
+    {
+        UpdateFiltering();
+        if (_filtering.layerMask == 0) return;
+
+        var drawingSettings = CreateDrawingSettings(ShaderTags, ctx.hdCamera, SortingCriteria.CommonTransparent);
+        ctx.renderContext.DrawRenderers(ctx.cullingResults, ref drawingSettings, ref _filtering, ref _stateBlock);
+    }
+
+    protected override void Cleanup() { }
+
+    void UpdateFiltering()
+    {
+        int mask = playerLayer.value;
+        _filtering = new FilteringSettings(RenderQueueRange.transparent, mask);
+    }
+}


### PR DESCRIPTION
## Summary
- clamp faded occluders to render before the player and restore their original render queues afterward
- keep player renderers on the PlayerReveal layer with depth write/prepass enabled and automatically install the HDRP reveal pass volume
- add the PlayerOccludedRevealPass custom pass and installer so PlayerNetwork brings the reveal volume online for the local camera

## Testing
- not run (editor-only changes)


------
https://chatgpt.com/codex/tasks/task_e_6906837b6d588328a23960caf3199435