### PR TITLE
Fix player yaw fallback from mouse aim

### DIFF
--- a/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
@@ -1136,20 +1136,29 @@ namespace Game.Net
                 if (!_hasValidYaw)
                 {
                     // Switch to mathematical plane intersection for robustness: always computes direction even without ground colliders.
-                    // Assumes flat ground at y=0; for uneven terrain, revert to Physics.Raycast with correct layers.
-                    Plane groundPlane = new Plane(Vector3.up, 0f);
+                    // Intersect against the player's height so uneven level offsets do not skew the aim vector.
+                    bool solved = false;
+                    Plane groundPlane = new Plane(Vector3.up, transform.position);
                     if (groundPlane.Raycast(ray, out float enter) && enter > 0f)
                     {
                         Vector3 hit = ray.GetPoint(enter);
                         Vector3 to = hit - transform.position;
                         to.y = 0f;
                         float sqr = to.sqrMagnitude;
-                        // Approximate pixel deadzone in world space (tuned empirically; assumes ~ortho size or FOV)
-                        float minWorldSqr = Mathf.Pow(screenAimMinPixels * (_isoCam ? _isoCam.orthographicSize : 20f) / _cam.pixelHeight, 2f);  // fallback 20 if no iso
+
+                        float minWorldSqr = 0f;
+                        if (_cam)
+                        {
+                            float orthoSize = _isoCam ? Mathf.Max(0.01f, _isoCam.orthographicSize) : 20f;
+                            float pixels = Mathf.Max(1f, _cam.pixelHeight);
+                            minWorldSqr = Mathf.Pow(screenAimMinPixels * orthoSize / pixels, 2f);
+                        }
+
                         if (sqr > minWorldSqr)
                         {
                             _targetYaw = Mathf.Atan2(to.x, to.z) * Mathf.Rad2Deg;
-                            _hasValidYaw = true;
+                            solved = true;
+
                             if (networkSyncYaw)
                             {
                                 float now = Time.unscaledTime;
@@ -1162,7 +1171,8 @@ namespace Game.Net
                             }
                         }
                     }
-                    _hasValidYaw = false;
+
+                    _hasValidYaw = solved;
                 }
 
                 // Brief dev comment: Using Plane.Raycast ensures we get a hit point without relying on physics colliders/layers, fixing cases where ground isn't set up correctly. For precise aiming on uneven terrain, use Physics.Raycast with a properly configured groundMask (e.g., including "Ground" layer) and ensure all floor/terrain colliders are on that layer.


### PR DESCRIPTION
## Summary
- ensure the ray-plane fallback for mouse aiming uses the player's height and preserves the computed yaw
- guard the deadzone calculation against missing camera data so the isometric yaw is considered valid when solved

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4c3133188328b8516503edca80fe)