### PR TITLE
Remove PlayerVisualAnchor MonoBehaviour from PlayerAvatar prefab

### DIFF
--- a/Assets/Prefabs/Player/PlayerAvatar.prefab
+++ b/Assets/Prefabs/Player/PlayerAvatar.prefab
@@ -284,7 +284,6 @@ GameObject:
   - component: {fileID: 643495328251867668}
   - component: {fileID: 3944781503140636565}
   - component: {fileID: 6125363240826229288}
-  - component: {fileID: 4610652831622128449}
   - component: {fileID: 6948204331012536248}
   - component: {fileID: 6409565688786376842}
   - component: {fileID: 6800541382982696214}
@@ -594,19 +593,6 @@ MonoBehaviour:
   skin: 0.02
   probeUp: 2
   probeDown: 6
---- !u!114 &4610652831622128449
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7629307799589511846}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a042a4f580cd6ab4899376ac09f1b08f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visualRoot: {fileID: 2175930713061618387}
 --- !u!114 &6948204331012536248
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- remove the obsolete PlayerVisualAnchor component reference from the PlayerAvatar prefab to eliminate the MonoBehaviour validation error

## Testing
- not run (editor-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690feaa10d7c83288cd959bc2fc0d036)