### PR TITLE
Ensure spawned player prefabs activate before NGO spawn

### DIFF
--- a/Assets/Scripts/Networking/Runtime/Gameplay/GamePlayerSpawner.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/GamePlayerSpawner.cs
@@ -80,7 +80,11 @@ namespace Game.Net
             pos.y += yLift;
 
             var inst = Instantiate(playerPrefab, pos, rot);
-            
+
+            // Guard against prefabs saved inactive; NGO requires active objects before spawn.
+            if (!inst.gameObject.activeSelf)
+                inst.gameObject.SetActive(true);
+
             // CRITICAL: Set phase based on server type BEFORE spawn.
             // This fallback spawner is used when there's no Match controller, so detect server type.
             var pn = inst.GetComponent<PlayerNetwork>();

--- a/Assets/Scripts/Networking/Runtime/Gameplay/LobbyPlayerSpawner.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/LobbyPlayerSpawner.cs
@@ -99,6 +99,10 @@ namespace Game.Net
 
             var inst = Instantiate(prefab, pose.pos, pose.rot);
 
+            // Ensure prefab instances are active before NGO spawn; prefab asset may be saved inactive for editor previews.
+            if (!inst.gameObject.activeSelf)
+                inst.gameObject.SetActive(true);
+
             // Ground and depenetrate before Spawn()
             var capsule = inst.GetComponent<CapsuleCollider>();
             AdjustToGroundAndResolve(inst.transform, capsule);

--- a/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
+++ b/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
@@ -388,6 +388,10 @@ namespace Game.Net
         {
             // Create at point, then clamp to Ground, then SpawnAsPlayerObject.
             var inst = Instantiate(playerPrefab);
+
+            // Ensure match instances are active prior to NGO spawn; prefab assets may be authored inactive for editor previews.
+            if (!inst.gameObject.activeSelf)
+                inst.gameObject.SetActive(true);
             var t = inst.transform;
 
             // Face neutral center.


### PR DESCRIPTION
## Summary
- force lobby, fallback, and match player instantiations to activate prefabs before calling SpawnAsPlayerObject
- document why the activation guard is required so inactive prefab assets no longer spawn disabled players

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fa259cbc8328a80fdcebf649b0d9)