### PR TITLE
Add spectator support across lobby and matches

### DIFF
--- a/Assets/Scripts/Networking/Runtime/Gameplay/GamePlayerSpawner.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/GamePlayerSpawner.cs
@@ -57,6 +57,14 @@ namespace Game.Net
         {
             if (!NM.IsServer) return;
 
+            if (Game.Net.ConnectionMetadata.IsSpectator(clientId))
+            {
+#if UNITY_EDITOR
+                Debug.Log($"[GamePlayerSpawner] Skip spectator {clientId} ({reason})");
+#endif
+                return;
+            }
+
             // If a Match controller is present, it owns spawning logic. Do not auto-spawn here.
 #if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
             var match = FindFirstObjectByType<Game.Net.Match1v1Controller>(FindObjectsInactive.Exclude);

--- a/Assets/Scripts/Networking/Runtime/Gameplay/SpectatorCameraController.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/SpectatorCameraController.cs
@@ -1,0 +1,272 @@
+// Assets/Scripts/Networking/Runtime/Gameplay/SpectatorCameraController.cs
+// Client-only camera controller for spectator clients. Follows live players or loops cinematic waypoints when none are alive.
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Game.Net
+{
+    public static class SpectatorCameraBootstrap
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        static void Install()
+        {
+            var cam = Camera.main;
+#if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
+            if (!cam) cam = UnityEngine.Object.FindFirstObjectByType<Camera>(FindObjectsInactive.Include);
+#else
+            if (!cam) cam = UnityEngine.Object.FindObjectOfType<Camera>();
+#endif
+            if (!cam) return;
+            if (!cam.gameObject.GetComponent<SpectatorCameraController>())
+                cam.gameObject.AddComponent<SpectatorCameraController>();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class SpectatorCameraController : MonoBehaviour
+    {
+        [Header("Targets")]
+        [SerializeField] private Transform[] cinematicWaypoints;
+        [SerializeField, Min(0.1f)] private float cinematicMoveSeconds = 6f;
+        [SerializeField, Min(0f)] private float cinematicPauseSeconds = 0.5f;
+        [SerializeField, Min(0.1f)] private float retargetIntervalSeconds = 0.5f;
+        [SerializeField] private LayerMask occluderMask = ~0;
+
+        private readonly List<PlayerNetwork> _candidates = new();
+        private Transform _currentTarget;
+        private Transform _cinematicFollower;
+        private int _waypointIndex;
+        private bool _waypointForward = true;
+        private float _pauseUntil;
+        private float _nextRefreshAt;
+
+        private IsometricCamera _isoCam;
+        private LineOfSightTransparency _los;
+
+        void Awake()
+        {
+            BindCamera();
+        }
+
+        void OnEnable()
+        {
+            if (!ConnectionMetadata.LocalIsSpectator)
+            {
+                enabled = false;
+                return;
+            }
+
+            EnsureCinematicFollower();
+            RefreshCandidates(true);
+            AutoChooseTarget();
+        }
+
+        void OnDisable()
+        {
+            SetFollowTarget(null);
+        }
+
+        void Update()
+        {
+            if (!ConnectionMetadata.LocalIsSpectator)
+            {
+                enabled = false;
+                return;
+            }
+
+            HandleInput();
+
+            if (Time.unscaledTime >= _nextRefreshAt)
+            {
+                RefreshCandidates();
+                _nextRefreshAt = Time.unscaledTime + retargetIntervalSeconds;
+            }
+
+            if (!IsValidTarget(_currentTarget))
+                AutoChooseTarget();
+
+            if (!IsValidTarget(_currentTarget))
+            {
+                AdvanceCinematic();
+            }
+        }
+
+        void HandleInput()
+        {
+            var kb = Keyboard.current;
+            if (kb == null) return;
+
+            if (kb.qKey.wasPressedThisFrame) Cycle(-1);
+            if (kb.eKey.wasPressedThisFrame) Cycle(1);
+        }
+
+        void Cycle(int direction)
+        {
+            if (_candidates.Count == 0) { _currentTarget = null; return; }
+
+            int currentIndex = -1;
+            for (int i = 0; i < _candidates.Count; i++)
+            {
+                if (_candidates[i] && _candidates[i].transform == _currentTarget)
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            int nextIndex = (currentIndex + direction) % _candidates.Count;
+            if (nextIndex < 0) nextIndex = _candidates.Count - 1;
+            SetFollowTarget(_candidates[nextIndex] ? _candidates[nextIndex].transform : null);
+        }
+
+        void RefreshCandidates(bool force = false)
+        {
+            _candidates.Clear();
+#if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
+            var players = FindObjectsByType<PlayerNetwork>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+#else
+            var players = FindObjectsOfType<PlayerNetwork>();
+#endif
+            foreach (var pn in players)
+            {
+                if (IsTargetable(pn))
+                    _candidates.Add(pn);
+            }
+
+            if (force && _candidates.Count > 0)
+                SetFollowTarget(_candidates[0].transform);
+        }
+
+        void AutoChooseTarget()
+        {
+            if (_candidates.Count > 0)
+            {
+                SetFollowTarget(_candidates[0].transform);
+            }
+            else
+            {
+                SetFollowTarget(null);
+            }
+        }
+
+        bool IsTargetable(PlayerNetwork pn)
+        {
+            if (!pn || !pn.IsSpawned) return false;
+            return pn.GetHealth() > 0.01f;
+        }
+
+        static bool IsValidTarget(Transform t)
+        {
+            return t && t.gameObject.activeInHierarchy;
+        }
+
+        void AdvanceCinematic()
+        {
+            EnsureCinematicFollower();
+            if (_cinematicFollower == null || cinematicWaypoints == null || cinematicWaypoints.Length == 0)
+                return;
+
+            if (!IsValidTarget(_currentTarget))
+                SetFollowTarget(_cinematicFollower);
+
+            if (Time.unscaledTime < _pauseUntil) return;
+
+            var target = cinematicWaypoints[_waypointIndex];
+            if (!target)
+            {
+                NextWaypoint();
+                return;
+            }
+
+            float t = cinematicMoveSeconds <= 0f ? 1f : Time.unscaledDeltaTime / cinematicMoveSeconds;
+            _cinematicFollower.position = Vector3.Lerp(_cinematicFollower.position, target.position, t);
+            _cinematicFollower.rotation = Quaternion.Slerp(_cinematicFollower.rotation, target.rotation, t);
+
+            if (Vector3.SqrMagnitude(_cinematicFollower.position - target.position) < 0.05f)
+            {
+                _pauseUntil = Time.unscaledTime + cinematicPauseSeconds;
+                NextWaypoint();
+            }
+        }
+
+        void NextWaypoint()
+        {
+            if (cinematicWaypoints == null || cinematicWaypoints.Length == 0) return;
+
+            if (_waypointForward)
+            {
+                _waypointIndex++;
+                if (_waypointIndex >= cinematicWaypoints.Length)
+                {
+                    _waypointIndex = cinematicWaypoints.Length - 2;
+                    _waypointForward = false;
+                }
+            }
+            else
+            {
+                _waypointIndex--;
+                if (_waypointIndex < 0)
+                {
+                    _waypointIndex = 1;
+                    _waypointForward = true;
+                }
+            }
+            _waypointIndex = Mathf.Clamp(_waypointIndex, 0, Mathf.Max(0, cinematicWaypoints.Length - 1));
+        }
+
+        void SetFollowTarget(Transform target)
+        {
+            EnsureCamera();
+            _currentTarget = target;
+
+            var follow = target;
+            if (!follow)
+            {
+                EnsureCinematicFollower();
+                follow = _cinematicFollower;
+            }
+
+            if (_isoCam) _isoCam.follow = follow;
+            if (_los)
+            {
+                _los.target = follow;
+                _los.occluderLayers = occluderMask;
+            }
+        }
+
+        void EnsureCinematicFollower()
+        {
+            if (_cinematicFollower != null) return;
+            var go = new GameObject("SpectatorCinematicFollower");
+            _cinematicFollower = go.transform;
+        }
+
+        void BindCamera()
+        {
+            EnsureCamera();
+            if (_isoCam)
+            {
+                _los = _isoCam.GetComponent<LineOfSightTransparency>() ?? _isoCam.gameObject.AddComponent<LineOfSightTransparency>();
+                _los.target = _isoCam.follow;
+                _los.occluderLayers = occluderMask;
+            }
+        }
+
+        void EnsureCamera()
+        {
+            if (_isoCam != null) return;
+            var cam = Camera.main;
+            if (!cam)
+            {
+#if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
+                cam = FindFirstObjectByType<Camera>(FindObjectsInactive.Include);
+#else
+                cam = FindObjectOfType<Camera>();
+#endif
+            }
+            if (!cam) return;
+            _isoCam = cam.GetComponent<IsometricCamera>() ?? cam.gameObject.AddComponent<IsometricCamera>();
+        }
+    }
+}

--- a/Assets/Scripts/Networking/Runtime/Infra/ConnectionMetadata.cs
+++ b/Assets/Scripts/Networking/Runtime/Infra/ConnectionMetadata.cs
@@ -1,0 +1,193 @@
+// Assets/Scripts/Networking/Runtime/Infra/ConnectionMetadata.cs
+// Stores connection payload metadata (e.g., spectator flag) and installs a permissive approval callback.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace Game.Net
+{
+    public static class ConnectionMetadataBootstrap
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void CreateInstaller()
+        {
+            var existing = GameObject.Find(nameof(ConnectionMetadataInstaller));
+            if (existing != null) return;
+
+            var go = new GameObject(nameof(ConnectionMetadataInstaller));
+            UnityEngine.Object.DontDestroyOnLoad(go);
+            go.AddComponent<ConnectionMetadataInstaller>();
+        }
+    }
+
+    [Serializable]
+    public struct ConnectionPayloadData
+    {
+        public string displayName;
+        public bool spectator;
+    }
+
+    /// <summary>
+    /// Central cache for connection metadata and a lightweight approval hook so servers can treat spectators separately.
+    /// </summary>
+    public static class ConnectionMetadata
+    {
+        private static readonly Dictionary<ulong, ConnectionPayloadData> s_ClientPayloads = new();
+        private static ConnectionPayloadData s_LocalPayload;
+
+        public static bool LocalIsSpectator => s_LocalPayload.spectator;
+
+        public static void SetLocalPayload(ConnectionPayloadData payload, NetworkManager nm = null)
+        {
+            s_LocalPayload = payload;
+            var manager = nm ? nm : NetworkManager.Singleton;
+            if (manager != null && manager.NetworkConfig != null)
+            {
+                manager.NetworkConfig.ConnectionData = Encode(payload);
+            }
+        }
+
+        internal static byte[] Encode(ConnectionPayloadData payload)
+        {
+            try
+            {
+                var json = JsonUtility.ToJson(payload);
+                return Encoding.UTF8.GetBytes(json);
+            }
+            catch
+            {
+                return Array.Empty<byte>();
+            }
+        }
+
+        internal static ConnectionPayloadData Decode(byte[] data)
+        {
+            if (data == null || data.Length == 0) return default;
+            try
+            {
+                var json = Encoding.UTF8.GetString(data);
+                return JsonUtility.FromJson<ConnectionPayloadData>(json);
+            }
+            catch
+            {
+                return default;
+            }
+        }
+
+        internal static void Register(ulong clientId, ConnectionPayloadData payload)
+        {
+            s_ClientPayloads[clientId] = payload;
+        }
+
+        internal static void Remove(ulong clientId) => s_ClientPayloads.Remove(clientId);
+
+        internal static void ClearAll() => s_ClientPayloads.Clear();
+
+        public static bool IsSpectator(ulong clientId)
+        {
+            return s_ClientPayloads.TryGetValue(clientId, out var payload) && payload.spectator;
+        }
+
+        public static ConnectionPayloadData GetPayload(ulong clientId)
+        {
+            s_ClientPayloads.TryGetValue(clientId, out var payload);
+            return payload;
+        }
+    }
+
+    /// <summary>
+    /// Runtime installer that enables connection approval and stashes spectator metadata server-side.
+    /// </summary>
+    public sealed class ConnectionMetadataInstaller : MonoBehaviour
+    {
+        void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+            Install();
+        }
+
+        void OnDestroy()
+        {
+            var nm = NetworkManager.Singleton;
+            if (nm != null)
+            {
+                nm.ConnectionApprovalCallback -= OnApproval;
+                nm.OnClientDisconnectCallback -= OnClientDisconnected;
+                nm.OnServerStopped -= OnServerStopped;
+            }
+        }
+
+        void Install()
+        {
+            var nm = NetworkManager.Singleton;
+#if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
+            if (nm == null) nm = FindFirstObjectByType<NetworkManager>(FindObjectsInactive.Include);
+#else
+            if (nm == null) nm = FindObjectOfType<NetworkManager>();
+#endif
+            if (nm == null)
+            {
+                StartCoroutine(WaitAndInstall());
+                return;
+            }
+
+            Configure(nm);
+        }
+
+        IEnumerator WaitAndInstall()
+        {
+            float t = 0f;
+            const float timeout = 15f;
+            NetworkManager nm = null;
+            while (t < timeout && nm == null)
+            {
+#if UNITY_2022_3_OR_NEWER || UNITY_6000_0_OR_NEWER
+                nm = FindFirstObjectByType<NetworkManager>(FindObjectsInactive.Include);
+#else
+                nm = FindObjectOfType<NetworkManager>();
+#endif
+                if (nm != null) break;
+                t += Time.unscaledDeltaTime;
+                yield return null;
+            }
+
+            if (nm != null) Configure(nm);
+        }
+
+        void Configure(NetworkManager nm)
+        {
+            if (nm.NetworkConfig != null)
+                nm.NetworkConfig.ConnectionApproval = true;
+
+            nm.ConnectionApprovalCallback -= OnApproval;
+            nm.ConnectionApprovalCallback += OnApproval;
+            nm.OnClientDisconnectCallback -= OnClientDisconnected;
+            nm.OnClientDisconnectCallback += OnClientDisconnected;
+            nm.OnServerStopped -= OnServerStopped;
+            nm.OnServerStopped += OnServerStopped;
+        }
+
+        static void OnApproval(NetworkManager.ConnectionApprovalRequest request, NetworkManager.ConnectionApprovalResponse response)
+        {
+            var payload = ConnectionMetadata.Decode(request.Payload);
+            ConnectionMetadata.Register(request.ClientNetworkId, payload);
+
+            response.Approved = true;
+            response.CreatePlayerObject = false; // PlayerObjects are spawned explicitly by match/lobby controllers.
+            response.Pending = false;
+        }
+
+        static void OnClientDisconnected(ulong clientId)
+        {
+            ConnectionMetadata.Remove(clientId);
+        }
+
+        static void OnServerStopped(bool _)
+        {
+            ConnectionMetadata.ClearAll();
+        }
+    }
+}

--- a/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
+++ b/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
@@ -9,6 +9,8 @@ using TMPro;
 using UnityEngine.Rendering;
 using UnityEngine.UI;
 using Game.Services;
+using Unity.Services.Lobbies;
+using Unity.Services.Lobbies.Models;
 
 namespace Game.Net
 {
@@ -93,7 +95,7 @@ namespace Game.Net
 // Removed legacy spawn-select framing settings.
 
         private readonly NetworkVariable<MatchState> _state = new();
-        private readonly NetworkVariable<int> _playerCount = new();
+    private readonly NetworkVariable<int> _playerCount = new();
         private readonly NetworkVariable<int> _roundNumber = new();
         private readonly NetworkVariable<float> _roundEndTime = new();
         private readonly NetworkVariable<int> _winsTeamA = new();
@@ -114,6 +116,9 @@ namespace Game.Net
         // Client state
         // removed _selecting, _myAreaBounds, _myAreaBlocked, _myTeam, _spawnDeadlineLocal, _selectCo, _spawnCursor
     private Coroutine _uiCo, _iconWarmupCo, _loadingDotsCo;
+    private Coroutine _lobbySyncCo;
+    private bool _lobbyDirty;
+    private float _nextLobbyPushAt;
 
     // Cinematic fields removed.
 
@@ -136,13 +141,18 @@ namespace Game.Net
                     fadeSeconds: 1f,
                     occluderMask: LayerMask.GetMask("Occluder", "OccluderExtra")
                 );
+
+                _lobbyDirty = true;
+                _nextLobbyPushAt = 0f;
+                StopCoroutineSafe(ref _lobbySyncCo);
+                _lobbySyncCo = StartCoroutine(CoSyncLobbyData());
             }
 
-            _state.OnValueChanged += (_, __) => RefreshUI();
-            _playerCount.OnValueChanged += (_, __) => RefreshUI();
-            _roundNumber.OnValueChanged += (_, __) => RefreshUI();
-            _winsTeamA.OnValueChanged += (_, __) => RefreshUI();
-            _winsTeamB.OnValueChanged += (_, __) => RefreshUI();
+            _state.OnValueChanged += (_, __) => { RefreshUI(); if (IsServer) MarkLobbyDirty(); };
+            _playerCount.OnValueChanged += (_, __) => { RefreshUI(); if (IsServer) MarkLobbyDirty(); };
+            _roundNumber.OnValueChanged += (_, __) => { RefreshUI(); if (IsServer) MarkLobbyDirty(); };
+            _winsTeamA.OnValueChanged += (_, __) => { RefreshUI(); if (IsServer) MarkLobbyDirty(); };
+            _winsTeamB.OnValueChanged += (_, __) => { RefreshUI(); if (IsServer) MarkLobbyDirty(); };
 
             if (IsClient)
             {
@@ -163,6 +173,8 @@ namespace Game.Net
 
         public override void OnNetworkDespawn()
         {
+            StopCoroutineSafe(ref _lobbySyncCo);
+
             if (IsServer)
             {
                 NetworkManager.OnClientConnectedCallback -= OnClientConnected;
@@ -224,9 +236,10 @@ namespace Game.Net
             int count = 0;
             var ids = NetworkManager.ConnectedClientsIds;
             for (int i = 0; i < ids.Count; i++)
-                if (ids[i] != NetworkManager.ServerClientId) count++;
+                if (ids[i] != NetworkManager.ServerClientId && !ConnectionMetadata.IsSpectator(ids[i])) count++;
             _playerCount.Value = count;
             RefreshUIClientRpc();
+            MarkLobbyDirty();
         }
 
         void AssignTeamsIfNeeded()
@@ -236,7 +249,7 @@ namespace Game.Net
             for (int i = 0; i < all.Count; i++)
             {
                 var cid = all[i];
-                if (cid != NetworkManager.ServerClientId) nonServer.Add(cid);
+                if (cid != NetworkManager.ServerClientId && !ConnectionMetadata.IsSpectator(cid)) nonServer.Add(cid);
             }
 
             // Stable order
@@ -252,6 +265,7 @@ namespace Game.Net
                 var player = NetworkManager.ConnectedClients[cid]?.PlayerObject?.GetComponent<PlayerNetwork>();
                 if (player) player.SetTeam(want);
             }
+            MarkLobbyDirty();
         }
 
         void TryStartFlow()
@@ -325,6 +339,7 @@ namespace Game.Net
             foreach (var cid in ids)
             {
                 if (cid == NetworkManager.ServerClientId) continue;
+                if (ConnectionMetadata.IsSpectator(cid)) continue;
                 if (!_teams.TryGetValue(cid, out var team)) continue;
 
                 Vector3 point = transform.position;
@@ -1038,6 +1053,103 @@ namespace Game.Net
             cg.blocksRaycasts = show;
             if (cg.gameObject.activeSelf != show)
                 cg.gameObject.SetActive(show);
+        }
+
+        void MarkLobbyDirty(float minDelaySeconds = 0.15f)
+        {
+            _lobbyDirty = true;
+            float now = Time.realtimeSinceStartup;
+            if (_nextLobbyPushAt <= 0f || _nextLobbyPushAt > now + minDelaySeconds)
+                _nextLobbyPushAt = now + minDelaySeconds;
+        }
+
+        IEnumerator CoSyncLobbyData()
+        {
+            const float minInterval = 5f;
+            while (true)
+            {
+                var lobby = SessionContext.CurrentLobby;
+                if (lobby == null || string.IsNullOrEmpty(lobby.Id))
+                {
+                    yield return new WaitForSecondsRealtime(2f);
+                    continue;
+                }
+
+                if (!_lobbyDirty && Time.realtimeSinceStartup < _nextLobbyPushAt)
+                {
+                    yield return null;
+                    continue;
+                }
+
+                _lobbyDirty = false;
+                _nextLobbyPushAt = Time.realtimeSinceStartup + minInterval;
+
+                var data = BuildLobbyData();
+                var opts = new UpdateLobbyOptions { Data = data };
+                try
+                {
+                    var task = LobbyService.Instance.UpdateLobbyAsync(lobby.Id, opts);
+                    while (!task.IsCompleted) yield return null;
+                    if (task.Exception != null)
+                    {
+                        Debug.LogWarning($"[Match1v1] Lobby update failed: {task.Exception.Message}");
+                        _nextLobbyPushAt = Time.realtimeSinceStartup + 10f;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning($"[Match1v1] Lobby sync exception: {ex.Message}");
+                    _nextLobbyPushAt = Time.realtimeSinceStartup + 10f;
+                }
+
+                yield return null;
+            }
+        }
+
+        Dictionary<string, DataObject> BuildLobbyData()
+        {
+            GetTeamCounts(out int aliveA, out int aliveB, out int totalA, out int totalB);
+            int total = totalA + totalB;
+            float elapsed = _state.Value == MatchState.Playing
+                ? Mathf.Max(0f, GetServerNowSafe() - _roundStartTimeServer)
+                : 0f;
+
+            return new Dictionary<string, DataObject>
+            {
+                ["MatchState"] = new DataObject(DataObject.VisibilityOptions.Public, _state.Value.ToString()),
+                ["Round"]      = new DataObject(DataObject.VisibilityOptions.Public, _roundNumber.Value.ToString()),
+                ["WinsA"]      = new DataObject(DataObject.VisibilityOptions.Public, _winsTeamA.Value.ToString()),
+                ["WinsB"]      = new DataObject(DataObject.VisibilityOptions.Public, _winsTeamB.Value.ToString()),
+                ["Alive"]      = new DataObject(DataObject.VisibilityOptions.Public, $"{aliveA + aliveB}/{Mathf.Max(1, total)}"),
+                ["AliveAB"]    = new DataObject(DataObject.VisibilityOptions.Public, $"{aliveA}/{aliveB}"),
+                ["Elapsed"]    = new DataObject(DataObject.VisibilityOptions.Public, Mathf.RoundToInt(elapsed).ToString())
+            };
+        }
+
+        void GetTeamCounts(out int aliveA, out int aliveB, out int totalA, out int totalB)
+        {
+            aliveA = aliveB = totalA = totalB = 0;
+
+            foreach (var kvp in _teams)
+            {
+                var cid = kvp.Key;
+                if (ConnectionMetadata.IsSpectator(cid)) continue;
+
+                var cc = NetworkManager.ConnectedClients.TryGetValue(cid, out var client) ? client : null;
+                var pn = cc?.PlayerObject ? cc.PlayerObject.GetComponent<PlayerNetwork>() : null;
+                bool alive = pn && pn.IsSpawned && pn.GetHealth() > 0.01f;
+
+                if (kvp.Value == TeamId.A)
+                {
+                    totalA++;
+                    if (alive) aliveA++;
+                }
+                else
+                {
+                    totalB++;
+                    if (alive) aliveB++;
+                }
+            }
         }
 
         // Safe server clock (works before NGO is listening)

--- a/Assets/Scripts/Networking/Runtime/NetworkConfigOptimizer.cs
+++ b/Assets/Scripts/Networking/Runtime/NetworkConfigOptimizer.cs
@@ -140,6 +140,7 @@ namespace Game.Net
 
             // NGO settings
             config.EnableSceneManagement = true;
+            config.ConnectionApproval = true; // Needed for spectator payloads and server-side role detection.
             // Enforce identical prefab tables across client/server to prevent desync.
             config.ForceSamePrefabs = true;
             config.RecycleNetworkIds = true;

--- a/Assets/Scripts/Networking/Runtime/UI/LobbyUI.cs
+++ b/Assets/Scripts/Networking/Runtime/UI/LobbyUI.cs
@@ -31,6 +31,15 @@ namespace Game.Net
         [SerializeField] private Button queue2v2Button;
         [SerializeField] private Button playCloseButton;
 
+        [Header("Spectate")]
+        [SerializeField] private Button spectateButton;
+        [SerializeField] private RectTransform spectatePanel;
+        [SerializeField] private CanvasGroup spectatePanelCg;
+        [SerializeField] private Button spectateCloseButton;
+        [SerializeField] private RectTransform spectateListRoot;
+        [SerializeField] private GameObject spectateEntryPrefab;
+        [SerializeField] private TMP_Text spectateStatusText;
+
         [Header("HUD")]
         [SerializeField] private GameObject playerHudRoot;
 
@@ -64,7 +73,10 @@ namespace Game.Net
         // runtime
         bool _busy;
         Coroutine _playStatusCo, _statsStatusCo, _armouryStatusCo;
+        Coroutine _spectateListCo;
         Canvas _rootCanvas;
+
+        bool _isSpectatorAccount;
 
         Vector3 _playDefaultScale, _statsDefaultScale, _armouryDefaultScale;
         Vector2 _playDefaultPos, _statsDefaultPos, _armouryDefaultPos;
@@ -100,6 +112,10 @@ namespace Game.Net
                 armouryPanel.gameObject.SetActive(false);
             }
             if (armouryStatusPanel) armouryStatusPanel.SetActive(false);
+
+            if (spectatePanel) spectatePanel.gameObject.SetActive(false);
+            if (spectateButton) spectateButton.gameObject.SetActive(false);
+            if (spectateStatusText) spectateStatusText.text = string.Empty;
         }
 
         void OnEnable()
@@ -108,8 +124,13 @@ namespace Game.Net
             if (queue2v2Button)   queue2v2Button.onClick.AddListener(QueueFor2v2);
             if (playCloseButton)  playCloseButton.onClick.AddListener(ClosePlayPanel);
 
+            if (spectateButton) spectateButton.onClick.AddListener(OpenSpectatePanel);
+            if (spectateCloseButton) spectateCloseButton.onClick.AddListener(CloseSpectatePanel);
+
             if (statsCloseButton)   statsCloseButton.onClick.AddListener(CloseStatsPanel);
             if (armouryCloseButton) armouryCloseButton.onClick.AddListener(CloseArmouryPanel);
+
+            StartCoroutine(DetectSpectatorAccount());
         }
 
         void OnDisable()
@@ -118,8 +139,13 @@ namespace Game.Net
             if (queue2v2Button)   queue2v2Button.onClick.RemoveListener(QueueFor2v2);
             if (playCloseButton)  playCloseButton.onClick.RemoveListener(ClosePlayPanel);
 
+            if (spectateButton) spectateButton.onClick.RemoveListener(OpenSpectatePanel);
+            if (spectateCloseButton) spectateCloseButton.onClick.RemoveListener(CloseSpectatePanel);
+
             if (statsCloseButton)   statsCloseButton.onClick.RemoveListener(CloseStatsPanel);
             if (armouryCloseButton) armouryCloseButton.onClick.RemoveListener(CloseArmouryPanel);
+
+            if (_spectateListCo != null) StopCoroutine(_spectateListCo);
         }
 
         // ---------- World-driven panel open ----------
@@ -208,6 +234,158 @@ namespace Game.Net
             _armouryLastCloseAt = Time.unscaledTime; _armouryLeftSinceClose = false;
         }
 
+        public void OpenSpectatePanel()
+        {
+            if (!_isSpectatorAccount || _busy) return;
+            if (!spectatePanel) return;
+
+            spectatePanel.gameObject.SetActive(true);
+            if (spectatePanelCg) spectatePanelCg.alpha = 1f;
+            PauseLocalPlayer(true);
+            if (_spectateListCo != null) StopCoroutine(_spectateListCo);
+            _spectateListCo = StartCoroutine(RefreshSpectateList());
+        }
+
+        public void CloseSpectatePanel()
+        {
+            if (!spectatePanel || !spectatePanel.gameObject.activeSelf) return;
+            if (_spectateListCo != null) StopCoroutine(_spectateListCo);
+            spectatePanel.gameObject.SetActive(false);
+            if (spectateStatusText) spectateStatusText.text = string.Empty;
+            PauseLocalPlayer(false);
+            _busy = false;
+            SetAllButtonsInteractable(true);
+        }
+
+        IEnumerator RefreshSpectateList()
+        {
+            if (spectateStatusText) spectateStatusText.text = "Scanning matches...";
+            ClearSpectateList();
+
+            var matches = new List<Lobby>();
+            yield return StartCoroutine(QueryMatchesForType("1v1", matches));
+            yield return StartCoroutine(QueryMatchesForType("2v2", matches));
+
+            if (matches.Count == 0)
+            {
+                if (spectateStatusText) spectateStatusText.text = "No active matches.";
+                yield break;
+            }
+
+            if (spectateStatusText) spectateStatusText.text = $"Open matches ({matches.Count})";
+            BuildSpectateEntries(matches);
+        }
+
+        IEnumerator QueryMatchesForType(string serverType, List<Lobby> output)
+        {
+            var opts = new QueryLobbiesOptions
+            {
+                Count = 25,
+                Filters = new List<QueryFilter>
+                {
+                    new QueryFilter(QueryFilter.FieldOptions.S1, serverType, QueryFilter.OpOptions.EQ)
+                }
+            };
+
+            var task = LobbyService.Instance.QueryLobbiesAsync(opts);
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            if (task.Exception == null && task.Result != null && task.Result.Results != null)
+            {
+                output.AddRange(task.Result.Results);
+            }
+        }
+
+        void BuildSpectateEntries(List<Lobby> matches)
+        {
+            var root = spectateListRoot ? spectateListRoot : spectatePanel;
+            if (!root) return;
+
+            foreach (var lobby in matches)
+            {
+                var entry = spectateEntryPrefab ? Instantiate(spectateEntryPrefab, root) : CreateRuntimeEntry(root);
+                var texts = entry.GetComponentsInChildren<TMP_Text>(true);
+                TMP_Text label = texts != null && texts.Length > 0 ? texts[0] : null;
+                var button = entry.GetComponentInChildren<Button>(true);
+
+                string name = lobby.Name;
+                lobby.Data?.TryGetValue("Scene", out var sceneData);
+                lobby.Data?.TryGetValue("ServerType", out var typeData);
+                lobby.Data?.TryGetValue("MatchState", out var stateData);
+                lobby.Data?.TryGetValue("Round", out var roundData);
+                lobby.Data?.TryGetValue("WinsA", out var winsA);
+                lobby.Data?.TryGetValue("WinsB", out var winsB);
+                lobby.Data?.TryGetValue("Alive", out var aliveData);
+                lobby.Data?.TryGetValue("AliveAB", out var aliveAbData);
+                lobby.Data?.TryGetValue("Elapsed", out var elapsedData);
+
+                string summary = $"{name} • {typeData?.Value ?? "Match"} @ {sceneData?.Value ?? "?"}\n" +
+                    $"State: {stateData?.Value ?? "Unknown"}  Round: {roundData?.Value ?? "?"}\n" +
+                    $"Score {winsA?.Value ?? "0"}-{winsB?.Value ?? "0"}  Alive {aliveAbData?.Value ?? aliveData?.Value ?? "?"}  Time {elapsedData?.Value ?? "0"}s";
+
+                if (label) label.text = summary;
+                if (button)
+                {
+                    button.onClick.RemoveAllListeners();
+                    button.onClick.AddListener(() =>
+                    {
+                        if (_busy) return;
+                        _busy = true;
+                        SetAllButtonsInteractable(false);
+                        _spectateListCo = StartCoroutine(ConnectToLobbyEndpoint(lobby, true, SetSpectateStatus));
+                    });
+                }
+            }
+        }
+
+        void ClearSpectateList()
+        {
+            var root = spectateListRoot ? spectateListRoot : spectatePanel;
+            if (!root) return;
+            for (int i = root.childCount - 1; i >= 0; i--)
+                Destroy(root.GetChild(i).gameObject);
+        }
+
+        GameObject CreateRuntimeEntry(RectTransform parent)
+        {
+            var go = new GameObject("SpectateEntry", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var bg = go.AddComponent<Image>();
+            bg.color = new Color(0f, 0f, 0f, 0.35f);
+
+            var layout = go.AddComponent<VerticalLayoutGroup>();
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = true;
+            layout.spacing = 4f;
+            layout.padding = new RectOffset(8, 8, 8, 8);
+
+            var textGo = new GameObject("Label", typeof(RectTransform));
+            textGo.transform.SetParent(go.transform, false);
+            var label = textGo.AddComponent<TMP_Text>();
+            label.fontSize = 18f;
+            label.alignment = TextAlignmentOptions.TopLeft;
+            label.enableWordWrapping = true;
+
+            var btnGo = new GameObject("JoinButton", typeof(RectTransform));
+            btnGo.transform.SetParent(go.transform, false);
+            var btnImage = btnGo.AddComponent<Image>();
+            btnImage.color = new Color(0.2f, 0.55f, 0.2f, 0.9f);
+            var btn = btnGo.AddComponent<Button>();
+            btn.targetGraphic = btnImage;
+            var btnLabelGo = new GameObject("Text", typeof(RectTransform));
+            btnLabelGo.transform.SetParent(btnGo.transform, false);
+            var btnLabel = btnLabelGo.AddComponent<TMP_Text>();
+            btnLabel.text = "Join as Spectator";
+            btnLabel.alignment = TextAlignmentOptions.Center;
+            btnLabel.fontSize = 16f;
+
+            var fitter = btnGo.AddComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            return go;
+        }
+
         // ---------- Play actions (Unity Lobby matchmaking with direct endpoints) ----------
     private void QueueFor1v1() => StartCoroutine(JoinMatch("1v1"));
     private void QueueFor2v2() => StartCoroutine(JoinMatch("2v2"));
@@ -274,29 +452,33 @@ namespace Game.Net
             var bestMatch = availableMatches[0];
             SetPlayStatus($"Joining {bestMatch.Name}...");
 
+            yield return StartCoroutine(ConnectToLobbyEndpoint(bestMatch, false, SetPlayStatus));
+        }
+
+        IEnumerator ConnectToLobbyEndpoint(Lobby lobby, bool asSpectator, System.Action<string> statusSetter)
+        {
+            statusSetter ??= SetPlayStatus;
+
             var nm = NetworkManager.Singleton;
             var utp = nm.GetComponent<UnityTransport>();
 
-            // Full handoff handled inside ReconnectAndConnect(); no pre-shutdown here.
-
-            // Do NOT join lobby. Use public endpoint advertised by server.
-            if (bestMatch.Data == null)
+            if (lobby.Data == null)
             {
                 Debug.LogError("[LobbyUI] Missing lobby public data");
-                SetPlayStatus("Invalid match data.");
+                statusSetter("Invalid match data.");
                 _busy = false;
                 SetAllButtonsInteractable(true);
                 yield break;
             }
 
-            bool hasHost = bestMatch.Data.TryGetValue("PublicHost", out var publicHostData);
-            bool hasPort = bestMatch.Data.TryGetValue("PublicPort", out var publicPortData);
-            string lanEp = bestMatch.Data.TryGetValue("LanEndpoint", out var lanEpData) ? lanEpData.Value : null;
+            bool hasHost = lobby.Data.TryGetValue("PublicHost", out var publicHostData);
+            bool hasPort = lobby.Data.TryGetValue("PublicPort", out var publicPortData);
+            string lanEp = lobby.Data.TryGetValue("LanEndpoint", out var lanEpData) ? lanEpData.Value : null;
 
             if (!hasHost || !hasPort || string.IsNullOrWhiteSpace(publicHostData.Value))
             {
                 Debug.LogError("[LobbyUI] No public endpoint on lobby");
-                SetPlayStatus("Invalid match data.");
+                statusSetter("Invalid match data.");
                 _busy = false;
                 SetAllButtonsInteractable(true);
                 yield break;
@@ -306,10 +488,14 @@ namespace Game.Net
             int publicPort = int.TryParse(publicPortData.Value, out var pp) ? pp : 7777;
 
             SessionContext.SetDirectEndpoint(publicHost, publicPort, lanEp);
+            ConnectionMetadata.SetLocalPayload(new ConnectionPayloadData
+            {
+                displayName = GetLocalDisplayName(),
+                spectator = asSpectator
+            }, nm);
 
             IEnumerator ReconnectAndConnect(string host, int prt, float seconds)
             {
-                // 1) Ensure old connection is *fully* stopped (not just IsConnectedClient=false).
                 if (nm.IsListening || nm.IsClient || nm.IsServer)
                 {
                     nm.Shutdown();
@@ -319,10 +505,9 @@ namespace Game.Net
                         t0 -= Time.unscaledDeltaTime;
                         yield return null;
                     }
-                    yield return null; // one extra frame for UTP cleanup
+                    yield return null;
                 }
 
-                // 2) Prefer IPv4 to avoid edge cases on some ISPs/routers.
                 string target = host;
                 try
                 {
@@ -333,18 +518,16 @@ namespace Game.Net
                         foreach (var a in addrs)
                             if (a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork) { target = a.ToString(); break; }
                     }
-                } catch {}
+                }
+                catch { }
 
-                // 3) Connect cleanly to the new endpoint.
                 utp.SetConnectionData(target, (ushort)prt);
                 if (!nm.StartClient()) yield break;
 
                 float t = seconds;
                 while (!nm.IsConnectedClient && t > 0f) { t -= Time.deltaTime; yield return null; }
             }
-            // Prevents "Cannot start Client while an instance is already running" by waiting for IsListening=false before StartClient().
 
-            // Prefer LAN endpoint if provided. Fallback to PublicHost.
             bool connected = false;
             if (!string.IsNullOrWhiteSpace(lanEp) && lanEp.Contains(":"))
             {
@@ -352,26 +535,25 @@ namespace Game.Net
                 var lh = parts[0].Trim();
                 var lp = (parts.Length > 1 && int.TryParse(parts[1], out var v)) ? v : publicPort;
 
-                SetPlayStatus($"Connecting (LAN) {lh}:{lp}...");
+                statusSetter($"Connecting (LAN) {lh}:{lp}...");
                 yield return StartCoroutine(ReconnectAndConnect(lh, lp, 5f));
                 connected = nm.IsConnectedClient;
             }
 
             if (!connected)
             {
-                SetPlayStatus($"Connecting {publicHost}:{publicPort}...");
+                statusSetter($"Connecting {publicHost}:{publicPort}...");
                 yield return StartCoroutine(ReconnectAndConnect(publicHost, publicPort, 10f));
             }
-            // Use the new handoff path for both LAN and public attempts.
 
             if (nm.IsConnectedClient)
             {
-                SetPlayStatus($"Joined {bestMatch.Name}.");
-                SessionContext.SetSession(bestMatch.Id, "");
+                statusSetter(asSpectator ? $"Spectating {lobby.Name}." : $"Joined {lobby.Name}.");
+                SessionContext.SetSession(lobby.Id, "");
             }
             else
             {
-                SetPlayStatus($"Connection failed to {bestMatch.Name}.");
+                statusSetter($"Connection failed to {lobby.Name}.");
                 nm.Shutdown();
             }
 
@@ -389,6 +571,11 @@ namespace Game.Net
                 if (_playStatusCo != null) StopCoroutine(_playStatusCo);
                 _playStatusCo = StartCoroutine(HidePlayStatusAfterDelay());
             }
+        }
+
+        private void SetSpectateStatus(string msg)
+        {
+            if (spectateStatusText) spectateStatusText.text = msg;
         }
 
         private IEnumerator HidePlayStatusAfterDelay()
@@ -509,7 +696,8 @@ namespace Game.Net
         {
             return (playPanel && playPanel.gameObject.activeSelf)
                 || (statsPanel && statsPanel.gameObject.activeSelf)
-                || (armouryPanel && armouryPanel.gameObject.activeSelf);
+                || (armouryPanel && armouryPanel.gameObject.activeSelf)
+                || (spectatePanel && spectatePanel.gameObject.activeSelf);
         }
 
         bool IsPanelOpen(LobbyPanel which)
@@ -530,6 +718,8 @@ namespace Game.Net
             if (playCloseButton)  playCloseButton.interactable = on;
             if (statsCloseButton) statsCloseButton.interactable = on;
             if (armouryCloseButton) armouryCloseButton.interactable = on;
+            if (spectateButton) spectateButton.interactable = on && !_busy && _isSpectatorAccount;
+            if (spectateCloseButton) spectateCloseButton.interactable = on;
         }
 
         void PauseLocalPlayer(bool pause)
@@ -541,6 +731,29 @@ namespace Game.Net
                 if (po) _localPlayer = po.GetComponent<PlayerNetwork>();
             }
             if (_localPlayer != null) _localPlayer.SetInputPaused(pause);
+        }
+
+        string GetLocalDisplayName()
+        {
+            var name = Game.Services.PlayerIdentityState.LocalDisplayName;
+            if (string.IsNullOrWhiteSpace(name) && AuthenticationService.Instance != null)
+                name = AuthenticationService.Instance.PlayerName;
+            return string.IsNullOrWhiteSpace(name) ? "Spectator" : name;
+        }
+
+        IEnumerator DetectSpectatorAccount()
+        {
+            var ensureTask = Game.Services.PlayerIdentityState.EnsureIdentityAsync();
+            while (!ensureTask.IsCompleted) yield return null;
+
+            var name = Game.Services.PlayerIdentityState.LocalDisplayName;
+            if (string.IsNullOrWhiteSpace(name))
+                name = AuthenticationService.Instance != null ? AuthenticationService.Instance.PlayerName : null;
+
+            _isSpectatorAccount = string.Equals(name, "Spectator1", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Spectator2", StringComparison.OrdinalIgnoreCase);
+
+            if (spectateButton) spectateButton.gameObject.SetActive(_isSpectatorAccount);
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
## Summary
- add connection metadata pipeline to flag spectator clients via approval payloads
- expose spectator browsing/joining from the lobby UI and connect with spectator payloads
- prevent spectators from spawning/affecting matches, publish live match stats, and add a spectator camera controller

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69202afe5b6c832882110f571ae90b2f)