### PR TITLE
Fix spectator lobby entries and FOV visuals

### DIFF
--- a/Assets/Scripts/Networking/Runtime/Gameplay/SpectatorCameraController.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/SpectatorCameraController.cs
@@ -43,6 +43,7 @@ namespace Game.Net
 
         private IsometricCamera _isoCam;
         private LineOfSightTransparency _los;
+        private FovMesh _activeFov;
 
         void Awake()
         {
@@ -220,6 +221,8 @@ namespace Game.Net
             EnsureCamera();
             _currentTarget = target;
 
+            UpdateTargetFov(target);
+
             var follow = target;
             if (!follow)
             {
@@ -267,6 +270,43 @@ namespace Game.Net
             }
             if (!cam) return;
             _isoCam = cam.GetComponent<IsometricCamera>() ?? cam.gameObject.AddComponent<IsometricCamera>();
+        }
+
+        void UpdateTargetFov(Transform target)
+        {
+            var pn = target ? target.GetComponentInParent<PlayerNetwork>() : null;
+
+            if (_activeFov && pn && _activeFov.transform == pn.transform)
+                return;
+
+            if (_activeFov)
+            {
+                _activeFov.enabled = false;
+                _activeFov.showVisual = false;
+                _activeFov = null;
+            }
+
+            if (!pn || !pn.IsSpawned || pn.GetHealth() <= 0.01f) return;
+
+            var fov = pn.GetComponent<FovMesh>();
+            if (!fov) fov = pn.gameObject.AddComponent<FovMesh>();
+
+            fov.radiusMeters = 12f;
+            fov.rayCount = 220;
+            fov.occluderMask = LayerMask.GetMask("Occluder", "OccluderExtra");
+            fov.showFill = true;
+            fov.fillColor = new Color(0.95f, 0.97f, 1.0f, 0.45f);
+            fov.fillIntensity = 1.15f;
+            fov.edgeFeather = 0.15f;
+            fov.showVisual = true;
+            fov.visualColor = new Color(0.92f, 0.97f, 1.0f, 0.62f);
+            fov.follow = pn.transform;
+            fov.enabled = true;
+
+            var constraint = pn.GetComponent<FovVisualConstraintBinder>() ?? pn.gameObject.AddComponent<FovVisualConstraintBinder>();
+            constraint.Source = pn.transform;
+
+            _activeFov = fov;
         }
     }
 }

--- a/Assets/Scripts/Networking/Runtime/UI/LobbyUI.cs
+++ b/Assets/Scripts/Networking/Runtime/UI/LobbyUI.cs
@@ -481,7 +481,7 @@ namespace Game.Net
 
             var textGo = new GameObject("Label", typeof(RectTransform));
             textGo.transform.SetParent(go.transform, false);
-            var label = textGo.AddComponent<TMP_Text>();
+            var label = textGo.AddComponent<TextMeshProUGUI>();
             label.fontSize = 18f;
             label.alignment = TextAlignmentOptions.TopLeft;
 #if UNITY_6000_0_OR_NEWER
@@ -498,7 +498,7 @@ namespace Game.Net
             btn.targetGraphic = btnImage;
             var btnLabelGo = new GameObject("Text", typeof(RectTransform));
             btnLabelGo.transform.SetParent(btnGo.transform, false);
-            var btnLabel = btnLabelGo.AddComponent<TMP_Text>();
+            var btnLabel = btnLabelGo.AddComponent<TextMeshProUGUI>();
             btnLabel.text = "Join as Spectator";
             btnLabel.alignment = TextAlignmentOptions.Center;
             btnLabel.fontSize = 16f;


### PR DESCRIPTION
## Summary
- fix runtime spectate list creation by using TextMeshProUGUI components instead of abstract TMP_Text
- ensure spectator camera enables and follows the active player's field-of-view visuals when cycling targets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692067c9fb008328a2e42b5602fc1ef2)