### PR TITLE
Ensure round health reset and weapon behaviors

### DIFF
--- a/Assets/Scripts/Net/Weapons/Melee/WeaponMeleeController.cs
+++ b/Assets/Scripts/Net/Weapons/Melee/WeaponMeleeController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Netcode;
 using UnityEngine;
@@ -14,6 +15,7 @@ namespace Game.Net.Weapons
         [Header("Melee Settings")]
         [SerializeField] float damage = 50f;
         [SerializeField] float range = 2.5f;
+        [SerializeField] float arcDegrees = 110f;
         [SerializeField] float swingCooldown = 0.8f;
         [SerializeField] LayerMask hitMask = -1; // All layers by default
 
@@ -23,6 +25,7 @@ namespace Game.Net.Weapons
         float _swingCooldownRemain;
         Game.Net.PlayerNetwork _player;
         bool _hasEquippedMelee;
+        readonly HashSet<ulong> _alreadyHit = new();
 
         // Local-only visuals
         WeaponView _view;
@@ -88,28 +91,31 @@ namespace Game.Net.Weapons
 
             _swingCooldownRemain = swingCooldown;
 
-            // Melee raycast from player forward
-            var origin = transform.position + Vector3.up * 1.0f; // Chest height
+            // Fan a short arc in front of the player and damage any enemy inside it.
+            var origin = sockets && sockets.meleeSwingPivot ? sockets.meleeSwingPivot.position : transform.position + Vector3.up * 1.0f;
             var direction = GetAimDir();
 
-            if (Physics.Raycast(origin, direction, out RaycastHit hit, range, hitMask))
+            _alreadyHit.Clear();
+
+            var cols = Physics.OverlapSphere(origin, range, hitMask, QueryTriggerInteraction.Collide);
+            foreach (var col in cols)
             {
-                var target = hit.collider.GetComponentInParent<Game.Net.PlayerNetwork>();
-                if (target)
-                {
-                    // Don't hit yourself
-                    if (target == _player || target.OwnerClientId == OwnerClientId) return;
+                var target = col.GetComponentInParent<Game.Net.PlayerNetwork>();
+                if (!target || target == _player || target.OwnerClientId == OwnerClientId) continue;
+                if (_alreadyHit.Contains(target.OwnerClientId)) continue;
 
-                    // Apply damage
-                    var ownerTeam = _player ? _player.GetTeam() : Game.Net.TeamId.A;
-                    var targetTeam = target.GetTeam();
+                var ownerTeam = _player ? _player.GetTeam() : Game.Net.TeamId.A;
+                var targetTeam = target.GetTeam();
+                if (ownerTeam == targetTeam) continue;
 
-                    // Only damage enemies
-                    if (ownerTeam != targetTeam)
-                    {
-                        target.ApplyHealthDelta(-Mathf.Abs(damage), _player);
-                    }
-                }
+                var toTarget = target.transform.position - origin; toTarget.y = 0f;
+                if (toTarget.sqrMagnitude < 0.0001f) continue;
+
+                float angle = Vector3.Angle(direction, toTarget);
+                if (angle > arcDegrees * 0.5f) continue;
+
+                _alreadyHit.Add(target.OwnerClientId);
+                target.ApplyHealthDelta(-Mathf.Abs(damage), _player);
             }
 
             // Play swing animation on all clients
@@ -126,6 +132,12 @@ namespace Game.Net.Weapons
 
         Vector3 GetAimDir()
         {
+            if (sockets && sockets.meleeFront)
+            {
+                var dir = sockets.meleeFront.forward; dir.y = 0f;
+                if (dir.sqrMagnitude > 0.0001f) return dir.normalized;
+            }
+
             // Horizontal forward of the player
             var fwd = transform.forward; fwd.y = 0f;
             if (fwd.sqrMagnitude < 0.0001f) fwd = Vector3.right;
@@ -144,7 +156,6 @@ namespace Game.Net.Weapons
 
         public void RebuildLocalViewImmediate()
         {
-            if (!IsOwner) return;
             if (_player && _player.GetActiveSlot() != Game.Net.WeaponSlot.Melee)
             {
                 Debug.Log("[Melee] Skip rebuild: slot not active.");
@@ -205,11 +216,12 @@ namespace Game.Net.Weapons
                 t.position = sockets.handMount.position; t.rotation = sockets.handMount.rotation;
             }
 
-            // Default facing toward Front point (uses tip if present)
-            if (_view && sockets.front)
+            // Default facing toward a melee-specific front (uses tip if present)
+            var meleeFront = sockets.meleeFront ? sockets.meleeFront : sockets.front;
+            if (_view && meleeFront)
             {
-                Debug.Log($"[Melee] SnapAimTo front='{sockets.front.name}' using tip={(bool)_view.tip}");
-                _view.SnapAimTo(sockets.front);
+                Debug.Log($"[Melee] SnapAimTo meleeFront='{meleeFront.name}' using tip={(bool)_view.tip}");
+                _view.SnapAimTo(meleeFront);
             }
 
             if (_view && sockets.equipStart && sockets.front)

--- a/Assets/Scripts/Net/Weapons/Primary/PlayerWeaponSockets.cs
+++ b/Assets/Scripts/Net/Weapons/Primary/PlayerWeaponSockets.cs
@@ -5,14 +5,19 @@ namespace Game.Net.Weapons
     /// Assign on the player prefab. Drag the three empty points in Inspector.
     public sealed class PlayerWeaponSockets : MonoBehaviour
     {
-        public Transform handMount;   // where weapon.grip attaches; Z+ roughly points forward from the palm, Y+ is up
-        public Transform equipStart;  // high point at equip (raise position)
-        public Transform front;       // normal forward hold/aim; place slightly in front of the hand, forward = aim, up = "blade up" for melee
+        public Transform handMount;        // where weapon.grip attaches; Z+ roughly points forward from the palm, Y+ is up
+        public Transform equipStart;       // high point at equip (raise position)
+        public Transform front;            // normal forward hold/aim; place slightly in front of the hand, forward = aim, up = "blade up" for melee
+        [Header("Melee Anchors")]
+        public Transform meleeFront;       // optional melee-specific aim/up reference so the tip points up in idle
+        public Transform meleeSwingPivot;  // optional swing origin (e.g., hand/torso) to drive arc damage queries
+        [Header("Utility Anchors")]
+        public Transform utilityThrowOrigin; // optional explicit throw origin for arc prediction/launch
 // Brief dev comment: for knives, tip alignment uses front.position for forward and front.up to decide which way the blade points.
 
         void Awake()
         {
-            Debug.Log($"[Sockets] player='{gameObject.name}' handMount={(handMount ? handMount.name : "null")} equipStart={(equipStart ? equipStart.name : "null")} front={(front ? front.name : "null")}");
+            Debug.Log($"[Sockets] player='{gameObject.name}' handMount={(handMount ? handMount.name : "null")} equipStart={(equipStart ? equipStart.name : "null")} front={(front ? front.name : "null")} meleeFront={(meleeFront ? meleeFront.name : "null")} meleeSwingPivot={(meleeSwingPivot ? meleeSwingPivot.name : "null")} utilThrow={(utilityThrowOrigin ? utilityThrowOrigin.name : "null")}");
         }
     }
 }

--- a/Assets/Scripts/Net/Weapons/Utility/ThrowableProjectile.cs
+++ b/Assets/Scripts/Net/Weapons/Utility/ThrowableProjectile.cs
@@ -18,6 +18,7 @@ namespace Game.Net.Weapons
         protected ulong _ownerClientId = ulong.MaxValue;
         protected Game.Net.TeamId _ownerTeam = Game.Net.TeamId.A;
         protected Game.Net.PlayerNetwork _owner;
+        protected bool _exploded;
 
         public override void OnNetworkSpawn()
         {
@@ -25,6 +26,7 @@ namespace Game.Net.Weapons
             if (IsServer)
             {
                 _fuseRemain = fuseTime;
+                _exploded = false;
             }
         }
 
@@ -35,9 +37,20 @@ namespace Game.Net.Weapons
             _fuseRemain -= Time.deltaTime;
             if (_fuseRemain <= 0f)
             {
-                Explode();
-                Despawn();
+                TriggerExplosion();
             }
+        }
+
+        void OnCollisionEnter(Collision collision)
+        {
+            if (!IsServer) return;
+            TriggerExplosion();
+        }
+
+        void OnTriggerEnter(Collider other)
+        {
+            if (!IsServer) return;
+            TriggerExplosion();
         }
 
         protected virtual void Explode()
@@ -70,11 +83,20 @@ namespace Game.Net.Weapons
             if (IsSpawned) NetworkObject.Despawn();
         }
 
+        protected void TriggerExplosion()
+        {
+            if (_exploded) return;
+            _exploded = true;
+            Explode();
+            Despawn();
+        }
+
         public void ConfigureServer(ulong ownerClientId, Game.Net.TeamId ownerTeam, Game.Net.PlayerNetwork owner)
         {
             _ownerClientId = ownerClientId;
             _ownerTeam = ownerTeam;
             _owner = owner;
+            _exploded = false;
         }
 
         [ClientRpc]

--- a/Assets/Scripts/Net/Weapons/Utility/WeaponUtilityController.cs
+++ b/Assets/Scripts/Net/Weapons/Utility/WeaponUtilityController.cs
@@ -38,6 +38,13 @@ namespace Game.Net.Weapons
         // Cached utility type used for local view rebuilds; driven by owner requests + server RPC.
         Game.Net.UtilityType _lastEquippedUtilityType = Game.Net.UtilityType.None;
         WeaponView _view;
+        LineRenderer _arcRenderer;
+        Transform _landingMarker;
+        float _lastServerThrowTime;
+
+        static readonly Color k_ArcColor = new(0.85f, 0.95f, 1f, 0.8f);
+        const int k_ArcSegments = 18;
+        const float k_PreviewDuration = 2.5f;
 
 // Brief dev comment: _lastEquippedUtilityType lets the owner build the correct view immediately without waiting on _netUtilityType replication.
 
@@ -211,8 +218,11 @@ namespace Game.Net.Weapons
         {
             if (!_hasEquippedUtility) return;
             if (ammoCount.Value <= 0) return;
+            if (_player && _player.GetActiveSlot() != Game.Net.WeaponSlot.Utility) return;
+            if (Time.time - _lastServerThrowTime < 0.1f) return;
 
             ammoCount.Value--;
+            _lastServerThrowTime = Time.time;
 
             var utilityType = (Game.Net.UtilityType)_netUtilityType.Value;
             GameObject prefab = utilityType switch
@@ -229,18 +239,31 @@ namespace Game.Net.Weapons
                 return;
             }
 
-            // Spawn throwable
-            var origin = transform.position + Vector3.up * 1.5f; // Shoulder height
-            var direction = GetThrowDirection();
+            if (!TryGetThrowSolution(out var origin, out var velocity))
+                return;
 
-            var go = Instantiate(prefab, origin, Quaternion.identity);
+            var go = Instantiate(prefab, origin, Quaternion.LookRotation(velocity.normalized, Vector3.up));
+
+            // Prevent immediate self-collisions on spawn.
+            var projCols = go.GetComponentsInChildren<Collider>();
+            if (projCols != null && _player)
+            {
+                var ownerCols = _player.GetComponentsInChildren<Collider>(true);
+                foreach (var pc in projCols)
+                {
+                    if (!pc) continue;
+                    foreach (var oc in ownerCols)
+                        if (oc) Physics.IgnoreCollision(pc, oc, true);
+                }
+            }
+
             var no = go.GetComponent<NetworkObject>();
             if (no) no.Spawn(true);
 
             var rb = go.GetComponent<Rigidbody>();
             if (rb)
             {
-                rb.AddForce(direction * throwForce, ForceMode.Impulse);
+                rb.velocity = velocity;
             }
 
             // Configure throwable if it has special script
@@ -255,6 +278,12 @@ namespace Game.Net.Weapons
 
         Vector3 GetAimDir()
         {
+            if (sockets && sockets.front)
+            {
+                var fwd = sockets.front.forward; fwd.y = 0f;
+                if (fwd.sqrMagnitude > 0.0001f) return fwd.normalized;
+            }
+
             // Horizontal forward of the player
             var fwd = transform.forward; fwd.y = 0f;
             if (fwd.sqrMagnitude < 0.0001f) fwd = Vector3.right;
@@ -268,6 +297,136 @@ namespace Game.Net.Weapons
             var angleRad = throwAngle * Mathf.Deg2Rad;
             var direction = horizontal + Vector3.up * Mathf.Tan(angleRad);
             return direction.normalized;
+        }
+
+        Vector3 GetThrowOrigin()
+        {
+            if (sockets && sockets.utilityThrowOrigin)
+                return sockets.utilityThrowOrigin.position;
+
+            if (_view && _view.grip)
+                return _view.grip.position;
+
+            return transform.position + Vector3.up * 1.5f; // shoulder height fallback
+        }
+
+        bool TryGetThrowSolution(out Vector3 origin, out Vector3 velocity)
+        {
+            origin = GetThrowOrigin();
+            var dir = GetThrowDirection();
+
+            if (dir.sqrMagnitude < 1e-6f)
+            {
+                velocity = Vector3.zero;
+                return false;
+            }
+
+            velocity = dir * throwForce;
+            return true;
+        }
+
+        void LateUpdate()
+        {
+            if (!IsOwner)
+            {
+                HideArcIndicator();
+                return;
+            }
+
+            if (_player && _player.GetActiveSlot() != Game.Net.WeaponSlot.Utility)
+            {
+                HideArcIndicator();
+                return;
+            }
+
+            if (!_hasEquippedUtility || ammoCount.Value <= 0)
+            {
+                HideArcIndicator();
+                return;
+            }
+
+            if (!TryGetThrowSolution(out var origin, out var velocity))
+            {
+                HideArcIndicator();
+                return;
+            }
+
+            DrawArcIndicator(origin, velocity);
+        }
+
+        void DrawArcIndicator(Vector3 origin, Vector3 velocity)
+        {
+            if (!_arcRenderer)
+            {
+                var go = new GameObject("UtilityArc");
+                go.transform.SetParent(transform, false);
+                _arcRenderer = go.AddComponent<LineRenderer>();
+                _arcRenderer.positionCount = k_ArcSegments;
+                _arcRenderer.useWorldSpace = true;
+                _arcRenderer.widthMultiplier = 0.05f;
+                _arcRenderer.material = new Material(Shader.Find("Sprites/Default"));
+                _arcRenderer.startColor = k_ArcColor;
+                _arcRenderer.endColor = k_ArcColor;
+                _arcRenderer.enabled = true;
+            }
+
+            var points = new Vector3[k_ArcSegments];
+            float dt = k_PreviewDuration / Mathf.Max(1, k_ArcSegments - 1);
+            var pos = origin;
+            var vel = velocity;
+            Vector3 landing = origin;
+
+            for (int i = 0; i < k_ArcSegments; i++)
+            {
+                points[i] = pos;
+                vel += Physics.gravity * dt;
+                var next = pos + vel * dt;
+
+                // Stop preview when we fall back to (or below) the spawn plane.
+                if (next.y <= origin.y)
+                {
+                    landing = next;
+                    points[i] = next;
+                    for (int j = i + 1; j < k_ArcSegments; j++) points[j] = next;
+                    break;
+                }
+
+                landing = next;
+                pos = next;
+            }
+
+            _arcRenderer.SetPositions(points);
+            _arcRenderer.enabled = true;
+            ShowLandingMarker(landing);
+        }
+
+        void ShowLandingMarker(Vector3 position)
+        {
+            if (!_landingMarker)
+            {
+                var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                go.name = "UtilityLanding";
+                Destroy(go.GetComponent<Collider>());
+                _landingMarker = go.transform;
+                _landingMarker.SetParent(transform, false);
+                _landingMarker.localScale = Vector3.one * 0.25f;
+                var renderer = go.GetComponent<MeshRenderer>();
+                if (renderer)
+                {
+                    renderer.material = new Material(Shader.Find("Standard"));
+                    renderer.material.color = new Color(0.8f, 1f, 0.9f, 0.6f);
+                }
+            }
+
+            _landingMarker.position = position;
+            if (_landingMarker.gameObject.activeSelf == false)
+                _landingMarker.gameObject.SetActive(true);
+        }
+
+        void HideArcIndicator()
+        {
+            if (_arcRenderer) _arcRenderer.enabled = false;
+            if (_landingMarker) _landingMarker.gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
+++ b/Assets/Scripts/Networking/Runtime/Gameplay/PlayerNetwork.cs
@@ -568,6 +568,13 @@ namespace Game.Net
             UpdateHealthUI(current);
         }
 
+        [ClientRpc]
+        void RefreshHealthHudClientRpc(float replicatedHealth, ClientRpcParams rpcParams = default)
+        {
+            // Targeted HUD refresh to immediately snap the owner UI to the latest replicated health.
+            UpdateHealthUI(replicatedHealth);
+        }
+
 // Brief dev comment: make explicit that the NetworkVariable change is the single source of health UI updates.
 
         void UpdateHealthUI(float current)
@@ -1083,22 +1090,17 @@ public void ForceActiveSlotServer(byte slot)
         {
             if (_inputPaused) return;
             if (_phase != PlayerPhase.Match) return;    // Lobby: block utility throw (client gate)
-            RequestThrowUtilityServerRpc();
-        }
-
-        [ServerRpc]
-        void RequestThrowUtilityServerRpc(ServerRpcParams p = default)
-        {
-            if (_phase != PlayerPhase.Match) return;    // Lobby: block utility throw (server gate)
             if (_netLoadout.Value.util == (byte)UtilityType.None) return;
 
-            if (Time.time - _lastThrowServerTime < k_MinThrowInterval) return;
-            _lastThrowServerTime = Time.time;
+            // Lightweight client-side rate limit before we ask the weapon to throw.
+            if (Time.time - _lastThrowServerTime < k_MinThrowInterval)
+                return;
 
-            // For now, just log. We will implement grenade entity later.
-#if UNITY_EDITOR
-    Debug.Log($"[Weapons] Throw utility: {(UtilityType)_netLoadout.Value.util}");
-#endif
+            var wu = GetComponent<Game.Net.Weapons.WeaponUtilityController>();
+            if (!wu) return;
+
+            _lastThrowServerTime = Time.time;
+            wu.RequestThrow();
         }
 
         void OnNetLoadoutChanged(Game.Net.NetLoadout previous, Game.Net.NetLoadout current)
@@ -2413,6 +2415,20 @@ public void SeedPhasePreSpawnServer(PlayerPhase phase)
         public void SetHealth(float health)
         {
             if (IsServer) _health.Value = Mathf.Clamp(health, 0f, 100f);
+        }
+
+        /// <summary>Server-only helper to force health to 100 and optionally ping the owner HUD immediately.</summary>
+        public void ServerResetHealthToFull(bool notifyOwnerHud)
+        {
+            if (!IsServer) return;
+
+            _health.Value = 100f;
+
+            if (notifyOwnerHud)
+            {
+                var rpc = TargetClientParams(OwnerClientId);
+                RefreshHealthHudClientRpc(_health.Value, rpc);
+            }
         }
 
         public CombatStats GetCombatStats() => _combatStats.Value;

--- a/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
+++ b/Assets/Scripts/Networking/Runtime/Match/Match1v1Controller.cs
@@ -456,7 +456,7 @@ namespace Game.Net
             if (pn)
             {
                 pn.SetTeam(team);
-                pn.SetHealth(100f);
+                pn.ServerResetHealthToFull(notifyOwnerHud: true);
 
                 // Replicate phase -> Match so clients enable Match systems.
                 pn.SetPhaseServerRpc(PlayerPhase.Match);
@@ -1268,7 +1268,7 @@ void ReequipAllPlayersServer()
         if (!pn) continue;
 
         // Force healthy & ready.
-        pn.SetHealth(100f);
+        pn.ServerResetHealthToFull(notifyOwnerHud: true);
         pn.ServerEnsureLoadoutValidAndEquip();
         count++;
     }
@@ -1287,21 +1287,22 @@ foreach (var pn in players)
 }
 
 // Brief dev comment: server sets the NV so the client equips Primary, fixes "pistol stuck" and restores weapon name/ammo HUD.
-void TopUpAndSanitizeAllPlayersServer()
-{
-    if (!IsServer) return;
-    int count = 0;
-    foreach (var cc in NetworkManager.ConnectedClientsList)
-    {
-        if (cc.ClientId == NetworkManager.ServerClientId) continue;
-        var pn = cc.PlayerObject ? cc.PlayerObject.GetComponent<PlayerNetwork>() : null;
-        if (!pn) continue;
-        // Guarantee: full health + non-None loadout before round starts.
-        pn.ServerEnsureValidLoadoutAndHealth(sanitizeOnly: false);
-        count++;
-    }
-    Debug.Log($"[Match1v1] TopUpAndSanitizeAllPlayersServer applied to {count} players");
-}
+        void TopUpAndSanitizeAllPlayersServer()
+        {
+            if (!IsServer) return;
+            int count = 0;
+            foreach (var cc in NetworkManager.ConnectedClientsList)
+            {
+                if (cc.ClientId == NetworkManager.ServerClientId) continue;
+                var pn = cc.PlayerObject ? cc.PlayerObject.GetComponent<PlayerNetwork>() : null;
+                if (!pn) continue;
+                // Guarantee: full health + non-None loadout before round starts.
+                pn.ServerResetHealthToFull(notifyOwnerHud: true);
+                pn.ServerEnsureValidLoadoutAndHealth(sanitizeOnly: false);
+                count++;
+            }
+            Debug.Log($"[Match1v1] TopUpAndSanitizeAllPlayersServer applied to {count} players");
+        }
 
 // Now guarantees both players start healthy and equipped each round.
 


### PR DESCRIPTION
## Summary
- reset player health server-side at round start and fan out HUD refreshes
- align melee sockets, show swings for all clients, and apply arc-based melee damage
- make utility throws server-authoritative with proper projectiles and client-side arc preview

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206cb3cb9c8328af336b6bfacd55f3)